### PR TITLE
added filter in multi_cache to return only requsted items

### DIFF
--- a/aiocache/decorators.py
+++ b/aiocache/decorators.py
@@ -334,7 +334,7 @@ class multi_cached:
             else:
                 asyncio.ensure_future(self.set_in_cache(result, f, args, kwargs))
 
-        return result
+        return {key: value for key, value in result.items() if key in keys}
 
     def get_cache_keys(self, f, args, kwargs):
         args_dict = _get_args_dict(f, args, kwargs)


### PR DESCRIPTION
Wrapped function can return dict with more keys, than required, they all will be cached, but also they all will be returned. In case of alive cache value, next calls to cache will return only required values. I would like to remove such inconsistency
Example:
```python
import asyncio
from typing import List, Dict

from aiocache import multi_cached


@multi_cached("ids", namespace="main")
async def foo(ids: List[int]) -> Dict[int, int]:
    return {id_: id_ ** 2 for id_ in range(min(ids), max(ids) + 1)}


async def amain():
    print(await foo(ids=[1, 3]))  # {1: 1, 2: 4, 3: 9}
    print(await foo(ids=[1, 3]))  # {1: 1, 3: 9}

if __name__ == "__main__":
    asyncio.run(amain())
```