### PR TITLE
Limit dependency version of aioredis before fixing compatibility with aioredis 2.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,9 +37,9 @@ setup(
     packages=find_packages(),
     install_requires=None,
     extras_require={
-        'redis:python_version<"3.7"': ['aioredis>=0.3.3'],
-        'redis:python_version>="3.8"': ['aioredis>=1.3.0'],
-        'redis:python_version>="3.7" and python_version<"3.8"': ['aioredis>=1.0.0'],
+        'redis:python_version<"3.7"': ['aioredis>=0.3.3', 'aioredis<2.0.0'],
+        'redis:python_version>="3.8"': ['aioredis>=1.3.0', 'aioredis<2.0.0'],
+        'redis:python_version>="3.7" and python_version<"3.8"': ['aioredis>=1.0.0', 'aioredis<2.0.0'],
         'memcached': ['aiomcache>=0.5.2'],
         'msgpack': ['msgpack>=0.5.5'],
         'dev': [


### PR DESCRIPTION
# What do these changes do?

<!-- Please give a short brief about these changes. -->

Limit dependency version of aioredis before fixing compatibility with aioredis 2.x

aioredis 2.0.0 released with **breaking API change**. Limit the dependency
of aioredis less than 2.0.0 before we fix the compatibility problem.

## Are there changes in behavior for the user?

Nope.

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
