### PR TITLE
[Bugfix] Add redis-py >= 4.2.0 support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -167,7 +167,7 @@ How does it work
 
 Aiocache provides 3 main entities:
 
-- **backends**: Allow you specify which backend you want to use for your cache. Currently supporting: SimpleMemoryCache, RedisCache using aioredis_ and MemCache using aiomcache_.
+- **backends**: Allow you specify which backend you want to use for your cache. Currently supporting: SimpleMemoryCache, RedisCache using redis_ and MemCache using aiomcache_.
 - **serializers**: Serialize and deserialize the data between your code and the backends. This allows you to save any Python object into your cache. Currently supporting: StringSerializer, PickleSerializer, JsonSerializer, and MsgPackSerializer. But you can also build custom ones.
 - **plugins**: Implement a hooks system that allows to execute extra behavior before and after of each command.
 
@@ -210,5 +210,5 @@ Documentation
 - `Examples <https://github.com/argaen/aiocache/tree/master/examples>`_
 
 
-.. _aioredis: https://github.com/aio-libs/aioredis
+.. _redis: https://github.com/redis/redis-py
 .. _aiomcache: https://github.com/aio-libs/aiomcache

--- a/aiocache/__init__.py
+++ b/aiocache/__init__.py
@@ -10,14 +10,14 @@ logger = logging.getLogger(__name__)
 AIOCACHE_CACHES: Dict[str, Type[BaseCache]] = {SimpleMemoryCache.NAME: SimpleMemoryCache}
 
 try:
-    import aioredis
+    import redis
 except ImportError:
-    logger.info("aioredis not installed, RedisCache unavailable")
+    logger.info("redis not installed, RedisCache unavailable")
 else:
     from aiocache.backends.redis import RedisCache
 
     AIOCACHE_CACHES[RedisCache.NAME] = RedisCache
-    del aioredis
+    del redis
 
 try:
     import aiomcache

--- a/aiocache/backends/redis.py
+++ b/aiocache/backends/redis.py
@@ -103,13 +103,12 @@ class RedisBackend:
         return await self.client.setex(key, ttl, value)
 
     async def _cas(self, key, value, token, ttl=None, _conn=None):
-        args = [value, token]
+        args = [key, value, token]
         if ttl is not None:
             if isinstance(ttl, float):
                 args += ["PX", int(ttl * 1000)]
             else:
                 args += ["EX", ttl]
-        args = [key] + args
         res = await self._raw("eval", self.CAS_SCRIPT, 1, *args, _conn=_conn)
         return res
 

--- a/aiocache/backends/redis.py
+++ b/aiocache/backends/redis.py
@@ -48,7 +48,7 @@ class RedisBackend:
         super().__init__(**kwargs)
         if loop is not None:
             warnings.warn(
-                "Parameter 'loop' has been obsolete on aiocache >= 0.12.0",
+                "Parameter 'loop' has been deprecated since aiocache 0.12",
                 DeprecationWarning,
             )
         if pool_min_size is not _NOT_SET:

--- a/aiocache/backends/redis.py
+++ b/aiocache/backends/redis.py
@@ -72,7 +72,7 @@ class RedisBackend:
         # (decode_responses=False), because some of the values are saved as
         # bytes directly, like pickle serialized values, which may raise an
         # exception when decoded with 'utf-8'.
-        self.client = redis.Redis(host=self.endpoint, port=self.port, db=self.db
+        self.client = redis.Redis(host=self.endpoint, port=self.port, db=self.db,
                                   password=self.password, decode_responses=False,
                                   socket_connect_timeout=self.create_connection_timeout,
                                   max_connections=self.pool_max_size)

--- a/aiocache/backends/redis.py
+++ b/aiocache/backends/redis.py
@@ -65,10 +65,8 @@ class RedisBackend:
         #  but doesn't wait for connection reuse when number of conns
         #  exceeds the limit. While in aioredis 1.x, it waits asynchronously
         #  via asyncio.Condition. So max pool size defaults to None in redis.
-        if pool_max_size is None:
-            self.pool_max_size = None
-        else:
-            self.pool_max_size = int(pool_max_size)
+        # TODO: Remove int() call some time after adding type annotations.
+        self.pool_max_size = None if pool_max_size is None else int(pool_max_size)
         self.create_connection_timeout = (
             float(create_connection_timeout) if create_connection_timeout else None
         )

--- a/aiocache/backends/redis.py
+++ b/aiocache/backends/redis.py
@@ -93,13 +93,10 @@ class RedisBackend:
         return await self._get(key, encoding=encoding, _conn=_conn)
 
     async def _multi_get(self, keys, encoding="utf-8", _conn=None):
-        values = []
-        for value in await self.client.mget(*keys):
-            if encoding is None or value is None:
-                values.append(value)
-            else:
-                values.append(value.decode(encoding))
-        return values
+        values = await self.client.mget(*keys)
+        if encoding is None:
+            return values
+        return [v if v is None else v.decode(encoding) for v in values]
 
     async def _set(self, key, value, ttl=None, _cas_token=None, _conn=None):
         if _cas_token is not None:

--- a/aiocache/backends/redis.py
+++ b/aiocache/backends/redis.py
@@ -182,7 +182,7 @@ class RedisBackend:
         if encoding is not None:
             if command == "get" and value is not None:
                 value = value.decode(encoding)
-            elif command in ["keys", "mget"]:
+            elif command in {"keys", "mget"}:
                 value = [_.decode(encoding) if _ is not None else _ for _ in value]
         return value
 

--- a/aiocache/backends/redis.py
+++ b/aiocache/backends/redis.py
@@ -61,10 +61,6 @@ class RedisBackend:
         self.port = int(port)
         self.db = int(db)
         self.password = password
-        # NOTE: In redis and aioredis 2.x, ConnectionPool raises ConnectionError
-        #  but doesn't wait for connection reuse when number of conns
-        #  exceeds the limit. While in aioredis 1.x, it waits asynchronously
-        #  via asyncio.Condition. So max pool size defaults to None in redis.
         # TODO: Remove int() call some time after adding type annotations.
         self.pool_max_size = None if pool_max_size is None else int(pool_max_size)
         self.create_connection_timeout = (

--- a/aiocache/backends/redis.py
+++ b/aiocache/backends/redis.py
@@ -103,14 +103,10 @@ class RedisBackend:
         return await self.client.setex(key, ttl, value)
 
     async def _cas(self, key, value, token, ttl=None, _conn=None):
-        args = [key, value, token]
+        args = ()
         if ttl is not None:
-            if isinstance(ttl, float):
-                args += ["PX", int(ttl * 1000)]
-            else:
-                args += ["EX", ttl]
-        res = await self._raw("eval", self.CAS_SCRIPT, 1, *args, _conn=_conn)
-        return res
+            args = ("PX", int(ttl * 1000)) if isinstance(ttl, float) else ("EX", ttl)
+        return await self._raw("eval", self.CAS_SCRIPT, 1, key, value, token, *args, _conn=_conn)
 
     async def _multi_set(self, pairs, ttl=None, _conn=None):
         ttl = ttl or 0

--- a/aiocache/backends/redis.py
+++ b/aiocache/backends/redis.py
@@ -142,9 +142,9 @@ class RedisBackend:
     async def _add(self, key, value, ttl=None, _conn=None):
         kwargs = {"nx": True}
         if isinstance(ttl, float):
-            kwargs.update({"px": int(ttl * 1000)})
+            kwargs["px"] = int(ttl * 1000)
         else:
-            kwargs.update({"ex": ttl})
+            kwargs["ex"] = ttl
         was_set = await self.client.set(key, value, **kwargs)
         if not was_set:
             raise ValueError("Key {} already exists, use .set to update the value".format(key))

--- a/aiocache/backends/redis.py
+++ b/aiocache/backends/redis.py
@@ -183,7 +183,7 @@ class RedisBackend:
             if command == "get" and value is not None:
                 value = value.decode(encoding)
             elif command in {"keys", "mget"}:
-                value = [_.decode(encoding) if _ is not None else _ for _ in value]
+                value = [v if v is None else v.decode(encoding) for v in value]
         return value
 
     async def _redlock_release(self, key, value):

--- a/aiocache/backends/redis.py
+++ b/aiocache/backends/redis.py
@@ -8,6 +8,9 @@ from aiocache.base import BaseCache
 from aiocache.serializers import JsonSerializer
 
 
+_NOT_SET = object()
+
+
 class RedisBackend:
 
     RELEASE_SCRIPT = (
@@ -36,7 +39,7 @@ class RedisBackend:
         port=6379,
         db=0,
         password=None,
-        pool_min_size=1,
+        pool_min_size=_NOT_SET,
         pool_max_size=10,
         loop=None,
         create_connection_timeout=None,
@@ -48,7 +51,7 @@ class RedisBackend:
                 "Parameter 'loop' has been obsolete on aiocache >= 0.12.0",
                 DeprecationWarning,
             )
-        if pool_min_size != 1:
+        if pool_min_size is not _NOT_SET:
             warnings.warn(
                 "Parameter 'pool_min_size' has been obsolete since aiocache >= 0.12.0",
                 DeprecationWarning,
@@ -214,7 +217,6 @@ class RedisCache(RedisBackend, BaseCache):
     :param port: int with the port to connect to. Default is 6379.
     :param db: int indicating database to use. Default is 0.
     :param password: str indicating password to use. Default is None.
-    :param pool_min_size: int minimum pool size for the redis connections pool. Default is 1
     :param pool_max_size: int maximum pool size for the redis connections pool. Default is 10
     :param create_connection_timeout: int timeout for the creation of connection. Default is None
     """

--- a/aiocache/backends/redis.py
+++ b/aiocache/backends/redis.py
@@ -53,7 +53,7 @@ class RedisBackend:
             )
         if pool_min_size is not _NOT_SET:
             warnings.warn(
-                "Parameter 'pool_min_size' has been obsolete since aiocache >= 0.12.0",
+                "Parameter 'pool_min_size' is deprecated since aiocache 0.12",
                 DeprecationWarning,
             )
 

--- a/aiocache/factory.py
+++ b/aiocache/factory.py
@@ -96,12 +96,12 @@ class Cache:
         a more advanced usage using queryparams to configure the cache:
 
         >>> from aiocache import Cache
-        >>> cache = Cache.from_url('redis://localhost:10/1?pool_min_size=1')
+        >>> cache = Cache.from_url('redis://localhost:10/1?pool_max_size=1')
         >>> cache
         RedisCache (localhost:10)
         >>> cache.db
         1
-        >>> cache.pool_min_size
+        >>> cache.pool_max_size
         1
 
         :param url: string identifying the resource uri of the cache to connect to

--- a/setup.py
+++ b/setup.py
@@ -33,9 +33,7 @@ setup(
     packages=find_packages(),
     install_requires=None,
     extras_require={
-        # todo: adapt code for aioredis 2.0
-        'redis:python_version<"3.8"': ["aioredis>=1.0.0,<2.0"],
-        'redis:python_version>="3.8"': ["aioredis>=1.3.0,<2.0"],
+        "redis": ["aioredis>=2.0.0"],
         "memcached": ["aiomcache>=0.5.2"],
         "msgpack": ["msgpack>=0.5.5"],
     },

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     packages=find_packages(),
     install_requires=None,
     extras_require={
-        "redis": ["aioredis>=2.0.0"],
+        "redis": ["redis>=4.2.0"],
         "memcached": ["aiomcache>=0.5.2"],
         "msgpack": ["msgpack>=0.5.5"],
     },

--- a/tests/acceptance/test_base.py
+++ b/tests/acceptance/test_base.py
@@ -153,7 +153,6 @@ class TestCache:
 
     @pytest.mark.asyncio
     async def test_single_connection(self, cache):
-        pytest.skip("aioredis code is broken")
         async with cache.get_connection() as conn:
             assert isinstance(conn, _Conn)
             assert await conn.set(Keys.KEY, "value") is True
@@ -269,6 +268,8 @@ class TestRedisCache:
         await redis_cache.raw("set", "key", "value")
         assert await redis_cache.raw("get", "key") == "value"
         assert await redis_cache.raw("keys", "k*") == ["key"]
+        # .raw() doesn't build key with namespace prefix, clear it manually
+        await redis_cache.raw("delete", "key")
 
     @pytest.mark.asyncio
     async def test_clear_with_namespace_redis(self, redis_cache):
@@ -281,4 +282,3 @@ class TestRedisCache:
     async def test_close(self, redis_cache):
         await redis_cache.set(Keys.KEY, "value")
         await redis_cache._close()
-        assert redis_cache._pool.size == 0

--- a/tests/acceptance/test_factory.py
+++ b/tests/acceptance/test_factory.py
@@ -26,7 +26,6 @@ class TestCache:
         assert cache.endpoint == "endpoint"
         assert cache.port == 1000
         assert cache.password == "pass"
-        assert cache.pool_min_size == 40
         assert cache.pool_max_size == 50
         assert cache.create_connection_timeout == 20
 

--- a/tests/acceptance/test_factory.py
+++ b/tests/acceptance/test_factory.py
@@ -18,7 +18,7 @@ class TestCache:
 
     def test_from_url_redis(self):
         cache = Cache.from_url(
-            "redis://endpoint:1000/0/?password=pass&pool_min_size=40"
+            "redis://endpoint:1000/0/?password=pass"
             "&pool_max_size=50&create_connection_timeout=20"
         )
 

--- a/tests/performance/conftest.py
+++ b/tests/performance/conftest.py
@@ -1,20 +1,14 @@
 import pytest
 
 from aiocache import Cache
-from aiocache.backends.redis import RedisBackend
-
-# TODO: Update aioredis and fix tests.
-collect_ignore_glob = ["*"]
 
 
 @pytest.fixture
-def redis_cache(event_loop):
+def redis_cache():
+    # redis connection pool raises ConnectionError but doesn't wait for conn reuse
+    #  when exceeding max pool size.
     cache = Cache(Cache.REDIS, namespace="test", pool_max_size=1)
     yield cache
-
-    for _, pool in RedisBackend.pools.items():
-        pool.close()
-        event_loop.run_until_complete(pool.wait_closed())
 
 
 @pytest.fixture

--- a/tests/performance/conftest.py
+++ b/tests/performance/conftest.py
@@ -2,15 +2,6 @@ import pytest
 
 from aiocache import Cache
 
-
-# TODO:
-#  1. concurrency_error_rates test doesn't work as expected with redis-py,
-#  where both ConnectionPool and BlockingConnectionPool raise ConnectionError
-#  but don't wait for connection reuse when number of conns exceeds the limit.
-#  That's why pool in redis-py uses an unlimit number connections by default.
-#  So no HTTP req should fails in the concurrency_error_rates test with redis-py.
-#  2. On my local machine, test_memcached_getsetdel() fails, it doesn't reach
-#  the performance target.
 collect_ignore_glob = ["*"]
 
 

--- a/tests/performance/conftest.py
+++ b/tests/performance/conftest.py
@@ -3,6 +3,17 @@ import pytest
 from aiocache import Cache
 
 
+# TODO:
+#  1. concurrency_error_rates test doesn't work as expected with redis-py,
+#  where both ConnectionPool and BlockingConnectionPool raise ConnectionError
+#  but don't wait for connection reuse when number of conns exceeds the limit.
+#  That's why pool in redis-py uses an unlimit number connections by default.
+#  So no HTTP req should fails in the concurrency_error_rates test with redis-py.
+#  2. On my local machine, test_memcached_getsetdel() fails, it doesn't reach
+#  the performance target.
+collect_ignore_glob = ["*"]
+
+
 @pytest.fixture
 def redis_cache():
     # redis connection pool raises ConnectionError but doesn't wait for conn reuse

--- a/tests/performance/test_concurrency.py
+++ b/tests/performance/test_concurrency.py
@@ -35,11 +35,7 @@ def memory_server():
     time.sleep(2)
 
 
-# TODO: following concurrency benchmark doesn't work as expected with redis-py,
-#  where both ConnectionPool and BlockingConnectionPool raise ConnectionError
-#  but don't wait for connection reuse when number of conns exceeds the limit.
-#  While in aioredis 1.x, it wait asynchronously with asyncio.Condition.
-@pytest.fixture(params=["memcached_server", "memory_server"])
+@pytest.fixture(params=["memcached_server", "memory_server", "redis_server"])
 def server(request):
     return request.getfixturevalue(request.param)
 

--- a/tests/performance/test_footprint.py
+++ b/tests/performance/test_footprint.py
@@ -1,8 +1,8 @@
 import time
 
 import aiomcache
-import redis.asyncio as redis
 import pytest
+import redis.asyncio as redis
 
 
 @pytest.fixture

--- a/tests/performance/test_footprint.py
+++ b/tests/performance/test_footprint.py
@@ -1,26 +1,26 @@
 import time
 
 import aiomcache
-import aioredis
+import redis.asyncio as redis
 import pytest
 
 
 @pytest.fixture
-async def redis():
-    return await aioredis.create_redis_pool(("127.0.0.1", 6379), maxsize=1)
+async def redis_client():
+    return redis.Redis(host="127.0.0.1", port=6379, max_connections=1)
 
 
 class TestRedis:
     @pytest.mark.asyncio
-    async def test_redis_getsetdel(self, redis, redis_cache):
+    async def test_redis_getsetdel(self, redis_client, redis_cache):
         N = 10000
-        aioredis_total_time = 0
+        redis_total_time = 0
         for _n in range(N):
             start = time.time()
-            await redis.set("hi", "value")
-            await redis.get("hi")
-            await redis.delete("hi")
-            aioredis_total_time += time.time() - start
+            await redis_client.set("hi", "value")
+            await redis_client.get("hi")
+            await redis_client.delete("hi")
+            redis_total_time += time.time() - start
 
         aiocache_total_time = 0
         for _n in range(N):
@@ -32,25 +32,25 @@ class TestRedis:
 
         print(
             "\n{:0.2f}/{:0.2f}: {:0.2f}".format(
-                aiocache_total_time, aioredis_total_time, aiocache_total_time / aioredis_total_time
+                aiocache_total_time, redis_total_time, aiocache_total_time / redis_total_time
             )
         )
         print("aiocache avg call: {:0.5f}s".format(aiocache_total_time / N))
-        print("aioredis avg call: {:0.5f}s".format(aioredis_total_time / N))
-        assert aiocache_total_time / aioredis_total_time < 1.30
+        print("redis    avg call: {:0.5f}s".format(redis_total_time / N))
+        assert aiocache_total_time / redis_total_time < 1.30
 
     @pytest.mark.asyncio
-    async def test_redis_multigetsetdel(self, redis, redis_cache):
+    async def test_redis_multigetsetdel(self, redis_client, redis_cache):
         N = 5000
-        aioredis_total_time = 0
+        redis_total_time = 0
         values = ["a", "b", "c", "d", "e", "f"]
         for _n in range(N):
             start = time.time()
-            await redis.mset(*[x for x in values * 2])
-            await redis.mget(*values)
+            await redis_client.mset({x: x for x in values})
+            await redis_client.mget(values)
             for k in values:
-                await redis.delete(k)
-            aioredis_total_time += time.time() - start
+                await redis_client.delete(k)
+            redis_total_time += time.time() - start
 
         aiocache_total_time = 0
         for _n in range(N):
@@ -63,12 +63,12 @@ class TestRedis:
 
         print(
             "\n{:0.2f}/{:0.2f}: {:0.2f}".format(
-                aiocache_total_time, aioredis_total_time, aiocache_total_time / aioredis_total_time
+                aiocache_total_time, redis_total_time, aiocache_total_time / redis_total_time
             )
         )
         print("aiocache avg call: {:0.5f}s".format(aiocache_total_time / N))
-        print("aioredis avg call: {:0.5f}s".format(aioredis_total_time / N))
-        assert aiocache_total_time / aioredis_total_time < 1.35
+        print("redis_client    avg call: {:0.5f}s".format(redis_total_time / N))
+        assert aiocache_total_time / redis_total_time < 1.35
 
 
 @pytest.fixture

--- a/tests/ut/backends/test_redis.py
+++ b/tests/ut/backends/test_redis.py
@@ -1,319 +1,268 @@
-from unittest.mock import ANY, AsyncMock, MagicMock, create_autospec, patch
+from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 import aioredis
 import pytest
 from tests.utils import Keys
 
-from aiocache.backends.redis import RedisBackend, RedisCache, conn
+from aiocache.backends.redis import RedisBackend, RedisCache
 from aiocache.base import BaseCache
 from aiocache.serializers import JsonSerializer
 
-pytest.skip("aioredis code is broken", allow_module_level=True)
 
+@pytest.fixture
+def redis_pipeline():
+    pipeline = AsyncMock(name="redis_pipeline")
+    for method in ["execute_command", "pexpire", "expire"]:
+        setattr(pipeline, method, MagicMock())
+    for method in ["__aexit__", "execute"]:
+        setattr(pipeline, method, AsyncMock())
 
-@pytest.fixture  # type: ignore[unreachable]
-def redis_connection():
-    return create_autospec(aioredis.RedisConnection)
+    pipeline.__aenter__.return_value = pipeline
+    yield pipeline
 
 
 @pytest.fixture
-def redis_pool(redis_connection):
-    class FakePool:
-        def __await__(self):
-            yield
-            return redis_connection
-
-    pool = FakePool()
-    pool._conn = redis_connection
-    pool.release = AsyncMock()
-    pool.clear = AsyncMock()
-    pool.acquire = AsyncMock(return_value=redis_connection)
-    pool.__call__ = MagicMock(return_value=pool)
-
-    return pool
-
-
-@pytest.fixture
-def redis(redis_pool):
-    redis = RedisBackend()
-    redis._pool = redis_pool
+def redis_client(redis_pipeline):
+    # "Redis.get()" is not a coroutine, but its return value is.
+    redis = AsyncMock(name="redis_client")
+    for method in [
+        "get", "mget", "set", "psetex", "setex", "execute_command", "exists",
+        "incrby", "persist", "delete", "keys", "flushdb",
+    ]:
+        setattr(redis, method, AsyncMock())
+    redis.pipeline = MagicMock(return_value=redis_pipeline)
     yield redis
 
 
 @pytest.fixture
-def create_pool():
-    with patch("aiocache.backends.redis.aioredis.create_pool") as create_pool:
-        yield create_pool
-
-
-@pytest.fixture(autouse=True)
-def mock_redis_v1(mocker, redis_connection):
-    mocker.patch("aiocache.backends.redis.aioredis.Redis", return_value=redis_connection)
-
-
+def redis(redis_client):
+    redis = RedisBackend()
+    redis.client = redis_client
+    yield redis
 class TestRedisBackend:
-    def test_setup(self):
+
+
+    default_redis_kwargs = {
+        "host": "127.0.0.1",
+        "port": 6379,
+        "db": 0,
+        "password": None,
+        "socket_connect_timeout": None,
+        "decode_responses": False,
+        "max_connections": 10,
+    }
+
+    @patch("aioredis.Redis", name="mock_class")
+    def test_setup(self, mock_class):
         redis_backend = RedisBackend()
+        kwargs = self.default_redis_kwargs.copy()
+        mock_class.assert_called_with(**kwargs)
         assert redis_backend.endpoint == "127.0.0.1"
         assert redis_backend.port == 6379
         assert redis_backend.db == 0
         assert redis_backend.password is None
-        assert redis_backend.pool_min_size == 1
         assert redis_backend.pool_max_size == 10
 
-    def test_setup_override(self):
-        redis_backend = RedisBackend(db=2, password="pass")
+    @patch("aioredis.Redis", name="mock_class")
+    def test_setup_override(self, mock_class):
+        override = {"db": 2, "password": "pass"}
+        redis_backend = RedisBackend(**override)
+
+        kwargs = self.default_redis_kwargs.copy()
+        kwargs.update(override)
+        mock_class.assert_called_with(**kwargs)
 
         assert redis_backend.endpoint == "127.0.0.1"
         assert redis_backend.port == 6379
         assert redis_backend.db == 2
         assert redis_backend.password == "pass"
 
-    def test_setup_casts(self):
-        redis_backend = RedisBackend(
-            db="2",
-            port="6379",
-            pool_min_size="1",
-            pool_max_size="10",
-            create_connection_timeout="1.5",
-        )
+    @patch("aioredis.Redis", name="mock_class")
+    def test_setup_casts(self, mock_class):
+        override = {
+            "db": "2",
+            "port": "6379",
+            "pool_max_size": "10",
+            "create_connection_timeout": "1.5",
+        }
+        redis_backend = RedisBackend(**override)
+
+        kwargs = self.default_redis_kwargs.copy()
+        kwargs.update({
+            "db": 2,
+            "port": 6379,
+            "max_connections": 10,
+            "socket_connect_timeout": 1.5,
+        })
+        mock_class.assert_called_with(**kwargs)
 
         assert redis_backend.db == 2
         assert redis_backend.port == 6379
-        assert redis_backend.pool_min_size == 1
         assert redis_backend.pool_max_size == 10
         assert redis_backend.create_connection_timeout == 1.5
 
     @pytest.mark.asyncio
-    async def test_acquire_conn(self, redis, redis_connection):
-        assert await redis.acquire_conn() == redis_connection
+    async def test_get(self, redis):
+        redis.client.get.return_value = b"value"
+        assert await redis._get(Keys.KEY) == "value"
+        redis.client.get.assert_called_with(Keys.KEY)
 
     @pytest.mark.asyncio
-    async def test_release_conn(self, redis):
-        conn = await redis.acquire_conn()
-        await redis.release_conn(conn)
-        redis._pool.release.assert_called_with(conn)
-
-    @pytest.mark.asyncio
-    async def test_get_pool_sets_pool(self, redis, redis_pool, create_pool):
-        redis._pool = None
-        await redis._get_pool()
-        assert redis._pool == create_pool.return_value
-
-    @pytest.mark.asyncio
-    async def test_get_pool_reuses_existing_pool(self, redis):
-        redis._pool = "pool"
-        await redis._get_pool()
-        assert redis._pool == "pool"
-
-    @pytest.mark.asyncio
-    async def test_get_pool_locked(self, mocker, redis, create_pool):
-        redis._pool = None
-        mocker.spy(redis._pool_lock, "acquire")
-        mocker.spy(redis._pool_lock, "release")
-
-        assert await redis._get_pool() == create_pool.return_value
-        assert redis._pool_lock.acquire.call_count == 1
-        assert redis._pool_lock.release.call_count == 1
-
-    @pytest.mark.asyncio
-    async def test_get_pool_calls_create_pool(self, redis, create_pool):
-        redis._pool = None
-        await redis._get_pool()
-        create_pool.assert_called_with(
-            (redis.endpoint, redis.port),
-            db=redis.db,
-            password=redis.password,
-            loop=redis._loop,
-            encoding="utf-8",
-            minsize=redis.pool_min_size,
-            maxsize=redis.pool_max_size,
-            create_connection_timeout=redis.create_connection_timeout,
-        )
-
-    @pytest.mark.asyncio
-    async def test_get(self, redis, redis_connection):
-        await redis._get(Keys.KEY)
-        redis_connection.get.assert_called_with(Keys.KEY, encoding="utf-8")
-
-    @pytest.mark.asyncio
-    async def test_gets(self, mocker, redis, redis_connection):
+    async def test_gets(self, mocker, redis, redis_client):
         mocker.spy(redis, "_get")
         await redis._gets(Keys.KEY)
         redis._get.assert_called_with(Keys.KEY, encoding="utf-8", _conn=ANY)
 
     @pytest.mark.asyncio
-    async def test_set(self, redis, redis_connection):
+    async def test_set(self, redis, redis_client):
         await redis._set(Keys.KEY, "value")
-        redis_connection.set.assert_called_with(Keys.KEY, "value")
+        redis_client.set.assert_called_with(Keys.KEY, "value")
 
         await redis._set(Keys.KEY, "value", ttl=1)
-        redis_connection.setex.assert_called_with(Keys.KEY, 1, "value")
+        redis_client.setex.assert_called_with(Keys.KEY, 1, "value")
 
     @pytest.mark.asyncio
-    async def test_set_cas_token(self, mocker, redis, redis_connection):
+    async def test_set_cas_token(self, mocker, redis, redis_client):
         mocker.spy(redis, "_cas")
-        await redis._set(Keys.KEY, "value", _cas_token="old_value", _conn=redis_connection)
+        await redis._set(Keys.KEY, "value", _cas_token="old_value", _conn=redis_client)
         redis._cas.assert_called_with(
-            Keys.KEY, "value", "old_value", ttl=None, _conn=redis_connection
+            Keys.KEY, "value", "old_value", ttl=None, _conn=redis_client
         )
 
     @pytest.mark.asyncio
-    async def test_cas(self, mocker, redis, redis_connection):
+    async def test_cas(self, mocker, redis, redis_client):
         mocker.spy(redis, "_raw")
-        await redis._cas(Keys.KEY, "value", "old_value", ttl=10, _conn=redis_connection)
+        await redis._cas(Keys.KEY, "value", "old_value", ttl=10, _conn=redis_client)
         redis._raw.assert_called_with(
             "eval",
             redis.CAS_SCRIPT,
-            [Keys.KEY],
-            ["value", "old_value", "EX", 10],
-            _conn=redis_connection,
+            1,
+            *[Keys.KEY, "value", "old_value", "EX", 10],
+            _conn=redis_client,
         )
 
     @pytest.mark.asyncio
-    async def test_cas_float_ttl(self, mocker, redis, redis_connection):
+    async def test_cas_float_ttl(self, mocker, redis, redis_client):
         mocker.spy(redis, "_raw")
-        await redis._cas(Keys.KEY, "value", "old_value", ttl=0.1, _conn=redis_connection)
+        await redis._cas(Keys.KEY, "value", "old_value", ttl=0.1, _conn=redis_client)
         redis._raw.assert_called_with(
             "eval",
             redis.CAS_SCRIPT,
-            [Keys.KEY],
-            ["value", "old_value", "PX", 100],
-            _conn=redis_connection,
+            1,
+            *[Keys.KEY, "value", "old_value", "PX", 100],
+            _conn=redis_client,
         )
 
     @pytest.mark.asyncio
-    async def test_multi_get(self, redis, redis_connection):
+    async def test_multi_get(self, redis):
         await redis._multi_get([Keys.KEY, Keys.KEY_1])
-        redis_connection.mget.assert_called_with(Keys.KEY, Keys.KEY_1, encoding="utf-8")
+        redis.client.mget.assert_called_with(Keys.KEY, Keys.KEY_1)
 
     @pytest.mark.asyncio
-    async def test_multi_set(self, redis, redis_connection):
+    async def test_multi_set(self, redis):
         await redis._multi_set([(Keys.KEY, "value"), (Keys.KEY_1, "random")])
-        redis_connection.mset.assert_called_with(Keys.KEY, "value", Keys.KEY_1, "random")
+        redis.client.execute_command.assert_called_with(
+            "MSET", Keys.KEY, "value", Keys.KEY_1, "random"
+        )
 
     @pytest.mark.asyncio
-    async def test_multi_set_with_ttl(self, redis, redis_connection):
+    async def test_multi_set_with_ttl(self, redis, redis_pipeline):
         await redis._multi_set([(Keys.KEY, "value"), (Keys.KEY_1, "random")], ttl=1)
-        assert redis_connection.multi_exec.call_count == 1
-        redis_connection.mset.assert_called_with(Keys.KEY, "value", Keys.KEY_1, "random")
-        redis_connection.expire.assert_any_call(Keys.KEY, timeout=1)
-        redis_connection.expire.assert_any_call(Keys.KEY_1, timeout=1)
-        assert redis_connection.execute.call_count == 1
+        assert redis.client.pipeline.call_count == 1
+        redis_pipeline.execute_command.assert_called_with(
+            "MSET", Keys.KEY, "value", Keys.KEY_1, "random"
+        )
+        redis_pipeline.expire.assert_any_call(Keys.KEY, time=1)
+        redis_pipeline.expire.assert_any_call(Keys.KEY_1, time=1)
+        assert redis_pipeline.execute.call_count == 1
 
     @pytest.mark.asyncio
-    async def test_add(self, redis, redis_connection):
+    async def test_add(self, redis):
         await redis._add(Keys.KEY, "value")
-        redis_connection.set.assert_called_with(Keys.KEY, "value", exist=ANY, expire=None)
+        redis.client.set.assert_called_with(Keys.KEY, "value", nx=True, ex=None)
 
         await redis._add(Keys.KEY, "value", 1)
-        redis_connection.set.assert_called_with(Keys.KEY, "value", exist=ANY, expire=1)
+        redis.client.set.assert_called_with(Keys.KEY, "value", nx=True, ex=1)
 
     @pytest.mark.asyncio
-    async def test_add_existing(self, redis, redis_connection):
-        redis_connection.set.return_value = False
+    async def test_add_existing(self, redis):
+        redis.client.set.return_value = False
         with pytest.raises(ValueError):
             await redis._add(Keys.KEY, "value")
 
     @pytest.mark.asyncio
-    async def test_add_float_ttl(self, redis, redis_connection):
+    async def test_add_float_ttl(self, redis):
         await redis._add(Keys.KEY, "value", 0.1)
-        redis_connection.set.assert_called_with(Keys.KEY, "value", exist=ANY, pexpire=100)
+        redis.client.set.assert_called_with(Keys.KEY, "value", nx=True, px=100)
 
     @pytest.mark.asyncio
-    async def test_exists(self, redis, redis_connection):
-        redis_connection.exists.return_value = 1
+    async def test_exists(self, redis):
+        redis.client.exists.return_value = 1
         await redis._exists(Keys.KEY)
-        redis_connection.exists.assert_called_with(Keys.KEY)
+        redis.client.exists.assert_called_with(Keys.KEY)
 
     @pytest.mark.asyncio
-    async def test_expire(self, redis, redis_connection):
-        await redis._expire(Keys.KEY, ttl=1)
-        redis_connection.expire.assert_called_with(Keys.KEY, 1)
-
-    @pytest.mark.asyncio
-    async def test_increment(self, redis, redis_connection):
+    async def test_increment(self, redis, redis_client):
         await redis._increment(Keys.KEY, delta=2)
-        redis_connection.incrby.assert_called_with(Keys.KEY, 2)
+        redis.client.incrby.assert_called_with(Keys.KEY, 2)
 
     @pytest.mark.asyncio
-    async def test_increment_typerror(self, redis, redis_connection):
-        redis_connection.incrby.side_effect = aioredis.errors.ReplyError("msg")
+    async def test_increment_typerror(self, redis):
+        redis.client.incrby.side_effect = aioredis.exceptions.ResponseError("msg")
         with pytest.raises(TypeError):
-            await redis._increment(Keys.KEY, 2)
+            await redis._increment(Keys.KEY, delta=2)
+        redis.client.incrby.assert_called_with(Keys.KEY, 2)
 
     @pytest.mark.asyncio
-    async def test_expire_0_ttl(self, redis, redis_connection):
+    async def test_expire(self, redis):
+        await redis._expire(Keys.KEY, 1)
+        redis.client.expire.assert_called_with(Keys.KEY, 1)
+        await redis._increment(Keys.KEY, 2)
+
+    @pytest.mark.asyncio
+    async def test_expire_0_ttl(self, redis, redis_client):
         await redis._expire(Keys.KEY, ttl=0)
-        redis_connection.persist.assert_called_with(Keys.KEY)
+        redis_client.persist.assert_called_with(Keys.KEY)
 
     @pytest.mark.asyncio
-    async def test_delete(self, redis, redis_connection):
+    async def test_delete(self, redis):
         await redis._delete(Keys.KEY)
-        redis_connection.delete.assert_called_with(Keys.KEY)
+        redis.client.delete.assert_called_with(Keys.KEY)
 
     @pytest.mark.asyncio
-    async def test_clear(self, redis, redis_connection):
-        redis_connection.keys.return_value = ["nm:a", "nm:b"]
+    async def test_clear(self, redis):
+        redis.client.keys.return_value = ["nm:a", "nm:b"]
         await redis._clear("nm")
-        redis_connection.delete.assert_called_with("nm:a", "nm:b")
+        redis.client.delete.assert_called_with("nm:a", "nm:b")
 
     @pytest.mark.asyncio
-    async def test_clear_no_keys(self, redis, redis_connection):
-        redis_connection.keys.return_value = []
+    async def test_clear_no_keys(self, redis):
+        redis.client.keys.return_value = []
         await redis._clear("nm")
-        redis_connection.delete.assert_not_called()
+        redis.client.delete.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_clear_no_namespace(self, redis, redis_connection):
+    async def test_clear_no_namespace(self, redis):
         await redis._clear()
-        assert redis_connection.flushdb.call_count == 1
+        assert redis.client.flushdb.call_count == 1
 
     @pytest.mark.asyncio
-    async def test_raw(self, redis, redis_connection):
+    async def test_raw(self, redis):
         await redis._raw("get", Keys.KEY)
         await redis._raw("set", Keys.KEY, 1)
-        redis_connection.get.assert_called_with(Keys.KEY, encoding=ANY)
-        redis_connection.set.assert_called_with(Keys.KEY, 1)
+        redis.client.get.assert_called_with(Keys.KEY)
+        redis.client.set.assert_called_with(Keys.KEY, 1)
 
     @pytest.mark.asyncio
     async def test_redlock_release(self, mocker, redis):
         mocker.spy(redis, "_raw")
         await redis._redlock_release(Keys.KEY, "random")
-        redis._raw.assert_called_with("eval", redis.RELEASE_SCRIPT, [Keys.KEY], ["random"])
+        redis._raw.assert_called_with("eval", redis.RELEASE_SCRIPT, 1, Keys.KEY, "random")
 
     @pytest.mark.asyncio
-    async def test_close_when_connected(self, redis):
-        await redis._raw("set", Keys.KEY, 1)
+    async def test_close(self, redis):
         await redis._close()
-        assert redis._pool.clear.call_count == 1
-
-    @pytest.mark.asyncio
-    async def test_close_when_not_connected(self, redis, redis_pool):
-        redis._pool = None
-        await redis._close()
-        assert redis_pool.clear.call_count == 0
-
-
-class TestConn:
-    async def dummy(self, *args, _conn=None, **kwargs):
-        pass
-
-    @pytest.mark.asyncio
-    async def test_conn(self, redis, redis_connection, mocker):
-        mocker.spy(self, "dummy")
-        d = conn(self.dummy)
-        await d(redis, "a", _conn=None)
-        self.dummy.assert_called_with(redis, "a", _conn=redis_connection)
-
-    @pytest.mark.asyncio
-    async def test_conn_reuses(self, redis, redis_connection, mocker):
-        mocker.spy(self, "dummy")
-        d = conn(self.dummy)
-        await d(redis, "a", _conn=redis_connection)
-        self.dummy.assert_called_with(redis, "a", _conn=redis_connection)
-        await d(redis, "a", _conn=redis_connection)
-        self.dummy.assert_called_with(redis, "a", _conn=redis_connection)
+        assert redis.client.close.call_count == 1
 
 
 class TestRedisCache:

--- a/tests/ut/backends/test_redis.py
+++ b/tests/ut/backends/test_redis.py
@@ -49,7 +49,7 @@ class TestRedisBackend:
         "password": None,
         "socket_connect_timeout": None,
         "decode_responses": False,
-        "max_connections": 10,
+        "max_connections": None,
     }
 
     @patch("redis.asyncio.Redis", name="mock_class")
@@ -61,7 +61,7 @@ class TestRedisBackend:
         assert redis_backend.port == 6379
         assert redis_backend.db == 0
         assert redis_backend.password is None
-        assert redis_backend.pool_max_size == 10
+        assert redis_backend.pool_max_size is None
 
     @patch("redis.asyncio.Redis", name="mock_class")
     def test_setup_override(self, mock_class):

--- a/tox.ini
+++ b/tox.ini
@@ -14,12 +14,12 @@ whitelist_externals =
   bash
 
 deps =
-  py{38,39}-deps-lowest: aioredis==1.3.0
-  py37-deps-lowest: aioredis==1.0.0
-  py36-deps-lowest: aioredis==0.3.3
+  py{38,39}-deps-lowest: redis==4.2.0
+  py37-deps-lowest: redis==4.2.0
+  py36-deps-lowest: redis==4.2.0
   deps-lowest: aiomcache==0.5.2
   deps-devel: https://github.com/aio-libs/aiomcache/archive/master.tar.gz
-  deps-devel: https://github.com/aio-libs/aioredis/archive/master.tar.gz
+  deps-devel: https://github.com/redis/redis-py/archive/master.tar.gz
 
   ujson: ujson
 


### PR DESCRIPTION
2022.05.12: switched backend from aioredis` to `redis-py >= 4.2.0`.

---

**Update**: 

- To test with `aioredis` 2.0.0 automatically. Travis and tox configurations need to be updated. 
- Fixes aio-libs/aiocache#543

## What do these changes do?

aioredis 2.0.0 released with breaking API change. Update current backend implementation of `airedis/backends/redis.py`.

Breaking aioredis changes encounter during making this PR. aio-libs/aioredis-py#1109

## Are there changes in behavior for the user?

Nope. Lower level redis backend change. No public API affected.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
