### PR TITLE
Use self instead of SimpleMemoryBackend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # CHANGELOG
 
+* Use `self` instead of hardcoded `SimpleMemoryBackend` to refer to cache and handlers [#551](https://github.com/aio-libs/aiocache/pull/551) - Andrey Semakin
 
 ## 0.11.1 (2019-07-31)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Use `self` instead of direct links to `SimpleMemoryBackend` class. This PR doesn't affect any functionality but allows users of the library inherit `SimpleMemoryBackend` and change its behaviour. Otherwise, changing the behavior is really difficult to do.

## Are there changes in behavior for the user?

No.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
