### PR TITLE
make SimpleMemoryBackend store state in instance instead of class

### DIFF
--- a/aiocache/backends/memory.py
+++ b/aiocache/backends/memory.py
@@ -1,5 +1,5 @@
 import asyncio
-from typing import Dict
+from typing import Any, Dict
 
 from aiocache.base import BaseCache
 from aiocache.serializers import NullSerializer
@@ -10,29 +10,29 @@ class SimpleMemoryBackend(BaseCache):
     Wrapper around dict operations to use it as a cache backend
     """
 
-    _cache: Dict[str, object] = {}
-    _handlers: Dict[str, asyncio.TimerHandle] = {}
-
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
+        self._cache: Dict[str, Any] = {}
+        self._handlers: Dict[str, asyncio.TimerHandle] = {}
+
     async def _get(self, key, encoding="utf-8", _conn=None):
-        return SimpleMemoryBackend._cache.get(key)
+        return self._cache.get(key)
 
     async def _gets(self, key, encoding="utf-8", _conn=None):
         return await self._get(key, encoding=encoding, _conn=_conn)
 
     async def _multi_get(self, keys, encoding="utf-8", _conn=None):
-        return [SimpleMemoryBackend._cache.get(key) for key in keys]
+        return [self._cache.get(key) for key in keys]
 
     async def _set(self, key, value, ttl=None, _cas_token=None, _conn=None):
-        if _cas_token is not None and _cas_token != SimpleMemoryBackend._cache.get(key):
+        if _cas_token is not None and _cas_token != self._cache.get(key):
             return 0
 
-        if key in SimpleMemoryBackend._handlers:
-            SimpleMemoryBackend._handlers[key].cancel()
+        if key in self._handlers:
+            self._handlers[key].cancel()
 
-        SimpleMemoryBackend._cache[key] = value
+        self._cache[key] = value
         if ttl:
             loop = asyncio.get_running_loop()
             SimpleMemoryBackend._handlers[key] = loop.call_later(ttl, self.__delete, key)
@@ -44,33 +44,33 @@ class SimpleMemoryBackend(BaseCache):
         return True
 
     async def _add(self, key, value, ttl=None, _conn=None):
-        if key in SimpleMemoryBackend._cache:
+        if key in self._cache:
             raise ValueError("Key {} already exists, use .set to update the value".format(key))
 
         await self._set(key, value, ttl=ttl)
         return True
 
     async def _exists(self, key, _conn=None):
-        return key in SimpleMemoryBackend._cache
+        return key in self._cache
 
     async def _increment(self, key, delta, _conn=None):
-        if key not in SimpleMemoryBackend._cache:
-            SimpleMemoryBackend._cache[key] = delta
+        if key not in self._cache:
+            self._cache[key] = delta
         else:
             try:
-                SimpleMemoryBackend._cache[key] = int(SimpleMemoryBackend._cache[key]) + delta
+                self._cache[key] = int(self._cache[key]) + delta
             except ValueError:
                 raise TypeError("Value is not an integer") from None
-        return SimpleMemoryBackend._cache[key]
+        return self._cache[key]
 
     async def _expire(self, key, ttl, _conn=None):
-        if key in SimpleMemoryBackend._cache:
-            handle = SimpleMemoryBackend._handlers.pop(key, None)
+        if key in self._cache:
+            handle = self._handlers.pop(key, None)
             if handle:
                 handle.cancel()
             if ttl:
                 loop = asyncio.get_running_loop()
-                SimpleMemoryBackend._handlers[key] = loop.call_later(ttl, self.__delete, key)
+                self._handlers[key] = loop.call_later(ttl, self.__delete, key)
             return True
 
         return False
@@ -80,27 +80,26 @@ class SimpleMemoryBackend(BaseCache):
 
     async def _clear(self, namespace=None, _conn=None):
         if namespace:
-            for key in list(SimpleMemoryBackend._cache):
+            for key in list(self._cache):
                 if key.startswith(namespace):
                     self.__delete(key)
         else:
-            SimpleMemoryBackend._cache = {}
-            SimpleMemoryBackend._handlers = {}
+            self._cache = {}
+            self._handlers = {}
         return True
 
     async def _raw(self, command, *args, encoding="utf-8", _conn=None, **kwargs):
-        return getattr(SimpleMemoryBackend._cache, command)(*args, **kwargs)
+        return getattr(self._cache, command)(*args, **kwargs)
 
     async def _redlock_release(self, key, value):
-        if SimpleMemoryBackend._cache.get(key) == value:
-            SimpleMemoryBackend._cache.pop(key)
+        if self._cache.get(key) == value:
+            self._cache.pop(key)
             return 1
         return 0
 
-    @classmethod
-    def __delete(cls, key):
-        if cls._cache.pop(key, None) is not None:
-            handle = cls._handlers.pop(key, None)
+    def __delete(self, key):
+        if self._cache.pop(key, None) is not None:
+            handle = self._handlers.pop(key, None)
             if handle:
                 handle.cancel()
             return 1

--- a/aiocache/backends/memory.py
+++ b/aiocache/backends/memory.py
@@ -35,7 +35,7 @@ class SimpleMemoryBackend(BaseCache):
         self._cache[key] = value
         if ttl:
             loop = asyncio.get_running_loop()
-            SimpleMemoryBackend._handlers[key] = loop.call_later(ttl, self.__delete, key)
+            self._handlers[key] = loop.call_later(ttl, self.__delete, key)
         return True
 
     async def _multi_set(self, pairs, ttl=None, _conn=None):

--- a/aiocache/backends/memory.py
+++ b/aiocache/backends/memory.py
@@ -1,5 +1,5 @@
 import asyncio
-from typing import Any, Dict
+from typing import Dict
 
 from aiocache.base import BaseCache
 from aiocache.serializers import NullSerializer
@@ -13,7 +13,7 @@ class SimpleMemoryBackend(BaseCache):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
-        self._cache: Dict[str, Any] = {}
+        self._cache: Dict[str, object] = {}
         self._handlers: Dict[str, asyncio.TimerHandle] = {}
 
     async def _get(self, key, encoding="utf-8", _conn=None):

--- a/tests/acceptance/test_plugins.py
+++ b/tests/acceptance/test_plugins.py
@@ -17,7 +17,7 @@ class TestHitMissRatioPlugin:
     async def test_get_hit_miss_ratio(self, memory_cache, data, ratio):
         keys = ["a", "b", "c", "d", "e", "f"]
         memory_cache.plugins = [HitMissRatioPlugin()]
-        SimpleMemoryBackend._cache = data
+        memory_cache._cache = data
 
         for key in keys:
             await memory_cache.get(key)
@@ -41,7 +41,7 @@ class TestHitMissRatioPlugin:
     async def test_multi_get_hit_miss_ratio(self, memory_cache, data, ratio):
         keys = ["a", "b", "c", "d", "e", "f"]
         memory_cache.plugins = [HitMissRatioPlugin()]
-        SimpleMemoryBackend._cache = data
+        memory_cache._cache = data
 
         for key in keys:
             await memory_cache.multi_get([key])
@@ -76,7 +76,7 @@ class TestTimingPlugin:
     async def test_get_avg_min_max(self, memory_cache, data, ratio):
         keys = ["a", "b", "c", "d", "e", "f"]
         memory_cache.plugins = [TimingPlugin()]
-        SimpleMemoryBackend._cache = data
+        memory_cache._cache = data
 
         for key in keys:
             await memory_cache.get(key)

--- a/tests/acceptance/test_plugins.py
+++ b/tests/acceptance/test_plugins.py
@@ -1,6 +1,5 @@
 import pytest
 
-from aiocache.backends.memory import SimpleMemoryBackend
 from aiocache.plugins import HitMissRatioPlugin, TimingPlugin
 
 

--- a/tests/ut/backends/test_memory.py
+++ b/tests/ut/backends/test_memory.py
@@ -6,7 +6,6 @@ import pytest
 from aiocache.backends.memory import SimpleMemoryBackend, SimpleMemoryCache
 from aiocache.base import BaseCache
 from aiocache.serializers import NullSerializer
-
 from ...utils import Keys
 
 

--- a/tests/ut/backends/test_memory.py
+++ b/tests/ut/backends/test_memory.py
@@ -6,21 +6,21 @@ import pytest
 from aiocache.backends.memory import SimpleMemoryBackend, SimpleMemoryCache
 from aiocache.base import BaseCache
 from aiocache.serializers import NullSerializer
+
 from ...utils import Keys
 
 
 @pytest.fixture
 def memory(mocker):
-    SimpleMemoryBackend._handlers = {}
-    SimpleMemoryBackend._cache = {}
-    mocker.spy(SimpleMemoryBackend, "_cache")
-    return SimpleMemoryBackend()
+    memory = SimpleMemoryBackend()
+    mocker.spy(memory, "_cache")
+    return memory
 
 
 class TestSimpleMemoryBackend:
     async def test_get(self, memory):
         await memory._get(Keys.KEY)
-        SimpleMemoryBackend._cache.get.assert_called_with(Keys.KEY)
+        memory._cache.get.assert_called_with(Keys.KEY)
 
     async def test_gets(self, mocker, memory):
         mocker.spy(memory, "_get")
@@ -29,7 +29,7 @@ class TestSimpleMemoryBackend:
 
     async def test_set(self, memory):
         await memory._set(Keys.KEY, "value")
-        SimpleMemoryBackend._cache.__setitem__.assert_called_with(Keys.KEY, "value")
+        memory._cache.__setitem__.assert_called_with(Keys.KEY, "value")
 
     async def test_set_no_ttl_no_handle(self, memory):
         await memory._set(Keys.KEY, "value", ttl=0)
@@ -54,22 +54,22 @@ class TestSimpleMemoryBackend:
     async def test_set_cas_token(self, memory):
         memory._cache.get.return_value = "old_value"
         assert await memory._set(Keys.KEY, "value", _cas_token="old_value") == 1
-        SimpleMemoryBackend._cache.__setitem__.assert_called_with(Keys.KEY, "value")
+        memory._cache.__setitem__.assert_called_with(Keys.KEY, "value")
 
     async def test_set_cas_fail(self, memory):
         memory._cache.get.return_value = "value"
         assert await memory._set(Keys.KEY, "value", _cas_token="old_value") == 0
-        assert SimpleMemoryBackend._cache.__setitem__.call_count == 0
+        assert memory._cache.__setitem__.call_count == 0
 
     async def test_multi_get(self, memory):
         await memory._multi_get([Keys.KEY, Keys.KEY_1])
-        SimpleMemoryBackend._cache.get.assert_any_call(Keys.KEY)
-        SimpleMemoryBackend._cache.get.assert_any_call(Keys.KEY_1)
+        memory._cache.get.assert_any_call(Keys.KEY)
+        memory._cache.get.assert_any_call(Keys.KEY_1)
 
     async def test_multi_set(self, memory):
         await memory._multi_set([(Keys.KEY, "value"), (Keys.KEY_1, "random")])
-        SimpleMemoryBackend._cache.__setitem__.assert_any_call(Keys.KEY, "value")
-        SimpleMemoryBackend._cache.__setitem__.assert_any_call(Keys.KEY_1, "random")
+        memory._cache.__setitem__.assert_any_call(Keys.KEY, "value")
+        memory._cache.__setitem__.assert_any_call(Keys.KEY_1, "random")
 
     async def test_add(self, memory, mocker):
         mocker.spy(memory, "_set")
@@ -77,66 +77,66 @@ class TestSimpleMemoryBackend:
         memory._set.assert_called_with(Keys.KEY, "value", ttl=None)
 
     async def test_add_existing(self, memory):
-        SimpleMemoryBackend._cache.__contains__.return_value = True
+        memory._cache.__contains__.return_value = True
         with pytest.raises(ValueError):
             await memory._add(Keys.KEY, "value")
 
     async def test_exists(self, memory):
         await memory._exists(Keys.KEY)
-        SimpleMemoryBackend._cache.__contains__.assert_called_with(Keys.KEY)
+        memory._cache.__contains__.assert_called_with(Keys.KEY)
 
     async def test_increment(self, memory):
         await memory._increment(Keys.KEY, 2)
-        SimpleMemoryBackend._cache.__contains__.assert_called_with(Keys.KEY)
-        SimpleMemoryBackend._cache.__setitem__.assert_called_with(Keys.KEY, 2)
+        memory._cache.__contains__.assert_called_with(Keys.KEY)
+        memory._cache.__setitem__.assert_called_with(Keys.KEY, 2)
 
     async def test_increment_missing(self, memory):
-        SimpleMemoryBackend._cache.__contains__.return_value = True
-        SimpleMemoryBackend._cache.__getitem__.return_value = 2
+        memory._cache.__contains__.return_value = True
+        memory._cache.__getitem__.return_value = 2
         await memory._increment(Keys.KEY, 2)
-        SimpleMemoryBackend._cache.__getitem__.assert_called_with(Keys.KEY)
-        SimpleMemoryBackend._cache.__setitem__.assert_called_with(Keys.KEY, 4)
+        memory._cache.__getitem__.assert_called_with(Keys.KEY)
+        memory._cache.__setitem__.assert_called_with(Keys.KEY, 4)
 
     async def test_increment_typerror(self, memory):
-        SimpleMemoryBackend._cache.__contains__.return_value = True
-        SimpleMemoryBackend._cache.__getitem__.return_value = "asd"
+        memory._cache.__contains__.return_value = True
+        memory._cache.__getitem__.return_value = "asd"
         with pytest.raises(TypeError):
             await memory._increment(Keys.KEY, 2)
 
     async def test_expire_no_handle_no_ttl(self, memory):
-        SimpleMemoryBackend._cache.__contains__.return_value = True
+        memory._cache.__contains__.return_value = True
         await memory._expire(Keys.KEY, 0)
         assert memory._handlers.get(Keys.KEY) is None
 
     async def test_expire_no_handle_ttl(self, memory):
-        SimpleMemoryBackend._cache.__contains__.return_value = True
+        memory._cache.__contains__.return_value = True
         await memory._expire(Keys.KEY, 1)
         assert isinstance(memory._handlers.get(Keys.KEY), asyncio.Handle)
 
     async def test_expire_handle_ttl(self, memory):
         fake = create_autospec(asyncio.TimerHandle, instance=True)
-        SimpleMemoryBackend._handlers[Keys.KEY] = fake
-        SimpleMemoryBackend._cache.__contains__.return_value = True
+        memory._handlers[Keys.KEY] = fake
+        memory._cache.__contains__.return_value = True
         await memory._expire(Keys.KEY, 1)
         assert fake.cancel.call_count == 1
         assert isinstance(memory._handlers.get(Keys.KEY), asyncio.Handle)
 
     async def test_expire_missing(self, memory):
-        SimpleMemoryBackend._cache.__contains__.return_value = False
+        memory._cache.__contains__.return_value = False
         assert await memory._expire(Keys.KEY, 1) is False
 
     async def test_delete(self, memory):
         fake = create_autospec(asyncio.TimerHandle, instance=True)
-        SimpleMemoryBackend._handlers[Keys.KEY] = fake
+        memory._handlers[Keys.KEY] = fake
         await memory._delete(Keys.KEY)
         assert fake.cancel.call_count == 1
-        assert Keys.KEY not in SimpleMemoryBackend._handlers
-        SimpleMemoryBackend._cache.pop.assert_called_with(Keys.KEY, None)
+        assert Keys.KEY not in memory._handlers
+        memory._cache.pop.assert_called_with(Keys.KEY, None)
 
     async def test_delete_missing(self, memory):
-        SimpleMemoryBackend._cache.pop.return_value = None
+        memory._cache.pop.return_value = None
         await memory._delete(Keys.KEY)
-        SimpleMemoryBackend._cache.pop.assert_called_with(Keys.KEY, None)
+        memory._cache.pop.assert_called_with(Keys.KEY, None)
 
     async def test_delete_non_truthy(self, memory):
         non_truthy = MagicMock(spec_set=("__bool__",))
@@ -145,44 +145,44 @@ class TestSimpleMemoryBackend:
         with pytest.raises(ValueError):
             bool(non_truthy)
 
-        SimpleMemoryBackend._cache.pop.return_value = non_truthy
+        memory._cache.pop.return_value = non_truthy
         await memory._delete(Keys.KEY)
 
         assert non_truthy.__bool__.call_count == 1
-        SimpleMemoryBackend._cache.pop.assert_called_with(Keys.KEY, None)
+        memory._cache.pop.assert_called_with(Keys.KEY, None)
 
     async def test_clear_namespace(self, memory):
-        SimpleMemoryBackend._cache.__iter__.return_value = iter(["nma", "nmb", "no"])
+        memory._cache.__iter__.return_value = iter(["nma", "nmb", "no"])
         await memory._clear("nm")
-        assert SimpleMemoryBackend._cache.pop.call_count == 2
-        SimpleMemoryBackend._cache.pop.assert_any_call("nma", None)
-        SimpleMemoryBackend._cache.pop.assert_any_call("nmb", None)
+        assert memory._cache.pop.call_count == 2
+        memory._cache.pop.assert_any_call("nma", None)
+        memory._cache.pop.assert_any_call("nmb", None)
 
     async def test_clear_no_namespace(self, memory):
-        SimpleMemoryBackend._handlers = "asdad"
-        SimpleMemoryBackend._cache = "asdad"
+        memory._handlers = "asdad"
+        memory._cache = "asdad"
         await memory._clear()
-        SimpleMemoryBackend._handlers = {}
-        SimpleMemoryBackend._cache = {}
+        memory._handlers = {}
+        memory._cache = {}
 
     async def test_raw(self, memory):
         await memory._raw("get", Keys.KEY)
-        SimpleMemoryBackend._cache.get.assert_called_with(Keys.KEY)
+        memory._cache.get.assert_called_with(Keys.KEY)
 
         await memory._set(Keys.KEY, "value")
-        SimpleMemoryBackend._cache.__setitem__.assert_called_with(Keys.KEY, "value")
+        memory._cache.__setitem__.assert_called_with(Keys.KEY, "value")
 
     async def test_redlock_release(self, memory):
-        SimpleMemoryBackend._cache.get.return_value = "lock"
+        memory._cache.get.return_value = "lock"
         assert await memory._redlock_release(Keys.KEY, "lock") == 1
-        SimpleMemoryBackend._cache.get.assert_called_with(Keys.KEY)
-        SimpleMemoryBackend._cache.pop.assert_called_with(Keys.KEY)
+        memory._cache.get.assert_called_with(Keys.KEY)
+        memory._cache.pop.assert_called_with(Keys.KEY)
 
     async def test_redlock_release_nokey(self, memory):
-        SimpleMemoryBackend._cache.get.return_value = None
+        memory._cache.get.return_value = None
         assert await memory._redlock_release(Keys.KEY, "lock") == 0
-        SimpleMemoryBackend._cache.get.assert_called_with(Keys.KEY)
-        assert SimpleMemoryBackend._cache.pop.call_count == 0
+        memory._cache.get.assert_called_with(Keys.KEY)
+        assert memory._cache.pop.call_count == 0
 
 
 class TestSimpleMemoryCache:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Make SimpleMemoryBackend store state in instance instead of class.
While current behaviour matches other caches (same connection args == same cache; zero connection args in memory case), current design seems bad since it does not allow extending and customizing memory cache in future.

Tests adjusted accordingly.

## Are there changes in behavior for the user?

Yes, if user for some reason expected different SimpleMemoryBackend objects to have shared storage. This is probably a breaking change for some weird setups.

## Related issue number

Resolves: #531

Resolves: #479
There is a PR aimed to fix it: https://github.com/aio-libs/aiocache/pull/523
But using namespace seem to not be sufficient. Instance local cache must be used for consistent behaviour.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
