### PR TITLE
Decorator @cached creates cache with the Cache() factory

### DIFF
--- a/aiocache/decorators.py
+++ b/aiocache/decorators.py
@@ -205,12 +205,7 @@ class cached_stampede(cached):
 
 
 def _get_cache(cache=Cache.MEMORY, serializer=None, plugins=None, **cache_kwargs):
-    return Cache(
-        cache, 
-        serializer=serializer, 
-        plugins=plugins, 
-        **cache_kwargs,
-    )
+    return Cache(cache,  serializer=serializer,  plugins=plugins,  **cache_kwargs)
 
 
 def _get_args_dict(func, args, kwargs):

--- a/aiocache/decorators.py
+++ b/aiocache/decorators.py
@@ -205,7 +205,7 @@ class cached_stampede(cached):
 
 
 def _get_cache(cache=Cache.MEMORY, serializer=None, plugins=None, **cache_kwargs):
-    return Cache(cache,  serializer=serializer,  plugins=plugins,  **cache_kwargs)
+    return Cache(cache, serializer=serializer, plugins=plugins, **cache_kwargs)
 
 
 def _get_args_dict(func, args, kwargs):

--- a/aiocache/decorators.py
+++ b/aiocache/decorators.py
@@ -205,7 +205,12 @@ class cached_stampede(cached):
 
 
 def _get_cache(cache=Cache.MEMORY, serializer=None, plugins=None, **cache_kwargs):
-    return cache(serializer=serializer, plugins=plugins, **cache_kwargs)
+    return Cache(
+        cache, 
+        serializer=serializer, 
+        plugins=plugins, 
+        **cache_kwargs,
+    )
 
 
 def _get_args_dict(func, args, kwargs):


### PR DESCRIPTION
* See #473 ~~: Deprecate using cache specific constructors~~
  ~~* https://github.com/aio-libs/aiocache/issues/473~~
  * `Cache` class was introduced as a proxy for instantiating the different
    backends. There should be only one way of doing things and `Cache` is
    the preferred way of doing that so will deprecate the others.
* This is now applied to `cached._get_cache()`

## What do these changes do?

Decorator `@cached` creates cache with the `Cache()` factory constructor, 
instead of the cache-specific constructor.

## Are there changes in behavior for the user?

This should be invisible to the end user.

## Related issue number

#473: Deprecate using cache specific constructors

## Checklist

- [X] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
