### PR TITLE
Use build_key(key, namespace) consistently across modules and classes

### DIFF
--- a/aiocache/backends/memory.py
+++ b/aiocache/backends/memory.py
@@ -79,9 +79,10 @@ class SimpleMemoryBackend:
         return self.__delete(key)
 
     async def _clear(self, namespace=None, _conn=None):
+        """Empty the cache for the namespace provided or the entire cache"""
         if namespace:
             for key in list(SimpleMemoryBackend._cache):
-                if key.startswith(namespace):
+                if self.key_filter(key, namespace):
                     self.__delete(key)
         else:
             SimpleMemoryBackend._cache = {}

--- a/aiocache/decorators.py
+++ b/aiocache/decorators.py
@@ -136,14 +136,16 @@ class cached:
 
     async def get_from_cache(self, key):
         try:
-            value = await self.cache.get(key)
+            namespace = self._kwargs.get("namespace", None)
+            value = await self.cache.get(key, namespace=namespace)
             return value
         except Exception:
             logger.exception("Couldn't retrieve %s, unexpected error", key)
 
     async def set_in_cache(self, key, value):
         try:
-            await self.cache.set(key, value, ttl=self.ttl)
+            namespace = self._kwargs.get("namespace", None)
+            await self.cache.set(key, value, namespace=namespace, ttl=self.ttl)
         except Exception:
             logger.exception("Couldn't set %s in key %s, unexpected error", value, key)
 

--- a/aiocache/decorators.py
+++ b/aiocache/decorators.py
@@ -205,7 +205,12 @@ class cached_stampede(cached):
 
 
 def _get_cache(cache=Cache.MEMORY, serializer=None, plugins=None, **cache_kwargs):
-    return cache(serializer=serializer, plugins=plugins, **cache_kwargs)
+    return Cache(
+        cache, 
+        serializer=serializer, 
+        plugins=plugins, 
+        **cache_kwargs,
+    )
 
 
 def _get_args_dict(func, args, kwargs):

--- a/aiocache/plugins.py
+++ b/aiocache/plugins.py
@@ -60,12 +60,15 @@ for method in API.CMDS:
     )
 
 
-class HitMissRatioPlugin(BasePlugin):
+class _HitMissRatioPlugin(BasePlugin):
     """
-    Calculates the ratio of hits the cache has. The data is saved in the cache class as a dict
-    attribute called ``hit_miss_ratio``. For example, to access the hit ratio of the cache,
-    you can do ``cache.hit_miss_ratio['hit_ratio']``. It also provides the "total" and "hits"
-    keys.
+    Calculates the ratio of hits the cache has. The data is saved in the 
+    cache class as a dict attribute called ``hit_miss_ratio``. 
+    For example, to access the hit ratio of the cache,
+    you can do ``cache.hit_miss_ratio['hit_ratio']``. 
+    It also provides the "total" and "hits" keys.
+
+    :param key: str should already include the namespace, if available
     """
 
     async def post_get(self, client, key, took=0, ret=None, **kwargs):
@@ -96,3 +99,22 @@ class HitMissRatioPlugin(BasePlugin):
         client.hit_miss_ratio["hit_ratio"] = (
             client.hit_miss_ratio["hits"] / client.hit_miss_ratio["total"]
         )
+
+
+class HitMissRatioPlugin(_HitMissRatioPlugin):
+    """
+    Calculates the ratio of hits the cache has. The data is saved in the 
+    cache class as a dict attribute called ``hit_miss_ratio``. 
+    For example, to access the hit ratio of the cache,
+    you can do ``cache.hit_miss_ratio['hit_ratio']``. 
+    It also provides the "total" and "hits" keys.
+
+    :param key: str should not include the namespace
+    """
+
+    async def post_get(self, client, key, took=0, ret=None, **kwargs):
+        """Update cache stats; use namespace if available"""
+        namespace = kwargs.get("namespace", None)
+        ns_key = client.build_key(key, namespace=namespace)
+        await super().post_get(client, ns_key, took=took, ret=ret, **kwargs)
+        return


### PR DESCRIPTION
* See #569 for more information
* Use namespace for decorators get/set
    * Include build_key(key, namespace) in decorators.cached:
        * get_from_cache()
	* set_in_cache()
* Use namespace for HitMissRatioPlugin key
    * Use namespace, if available, to build key that is passed
       to plugins.HitMissRatioPlugin.post_get()
* Introduce key_filter for confirming key is in namespace
    * `BaseCache.key_filter(key, namespace)` returns True
      if key is in the namespace
    * `backends.memory.SimpleMemoryBackend` uses this to seleectively
      clear its cache for the given namespace

## What do these changes do?

Keys with namespaces now work throughout the `aiocache` package 

* Use namespace for decorators get/set
* Use namespace for HitMissRatioPlugin key
* Introduce key_filter for confirming key is in namespace

## Are there changes in behavior for the user?

Keys with namespaces now work throughout the `aiocache` package.
This includes using:
* the `@cached()` decorator
* the `HitMissRatioPlugin` plugin
* the `SimpleMemoryCache.clear()` member

## Related issue number

#569: `build_key(key, namespace)` is missing from some modules/classes

## Checklist

- [X] I think the code is well written
- [ ] Unit tests for the changes exist
- [X] Documentation reflects the changes
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
