### PR TITLE
Add py.typed file in python package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+global-include py.typed

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,0 @@
-global-include py.typed

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,7 @@
+[options.package_data]
+aiocache =
+    = py.typed
+
 [bdist_wheel]
 universal=1
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

The file `py.typed` is present but it's not deployed/used when we use the latest commit.

This PR adds the missing "code" to add the `py.typed` file in the python package

## Are there changes in behavior for the user?

The package will be see as typed package by mypy and alternatives

## Related issue number


## Checklist

- [X] I think the code is well written
- [X] Unit tests for the changes exist
- [X] Documentation reflects the changes
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
