### PR TITLE
Reenable multiprocessing in coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,4 @@
+[run]
+concurrency = multiprocessing
+parallel = true
+sigterm = true

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,2 @@
 [run]
 concurrency = multiprocessing
-parallel = true
-sigterm = true


### PR DESCRIPTION
This ensures coverage includes the subprocess run for tests/performance/server.py