### PR TITLE
Clarify __init__ params for decorator multi_cached

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,14 @@
 * Remove deprecated ``loop`` parameters.
 * Remove deprecated ``cache`` parameter from ``create()``.
 * Use ``base._ensure_key()`` in ``_build_key()`` to ensure consistency of enum
-keys between different Python versions. [#633](https://github.com/aio-libs/aiocache/issues/633) - Padraic Shafer
-* Improved support for ``build_key(key, namespace)`` [#569](https://github.com/aio-libs/aiocache/issues/569) - Padraic Shafer
+keys between different Python versions. [#633](https://github.com/aio-libs/aiocache/issues/633) -- Padraic Shafer
+* Improved support for ``build_key(key, namespace)`` [#569](https://github.com/aio-libs/aiocache/issues/569) -- Padraic Shafer
     * `BaseCache.build_key` uses `namespace` argument if provided,
     otherwise it uses `self.namespace`.
     * Cache locks use `client.build_key` rather than `client._build_key`.
     * Include examples of using a custom `key_builder` when creating a cache.
     * Warn when decorator parameters are unused because alias takes precedence.
-* Clarify `__init__` params for decorator `multi_cached` [#636](https://github.com/aio-libs/aiocache/issues/636) - Padraic Shafer
+* Clarify `__init__` params for decorator `multi_cached` [#636](https://github.com/aio-libs/aiocache/issues/636) -- Padraic Shafer
 
 ## 0.11.1 (2019-07-31)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,14 @@
 * Remove deprecated ``loop`` parameters.
 * Remove deprecated ``cache`` parameter from ``create()``.
 * Use ``base._ensure_key()`` in ``_build_key()`` to ensure consistency of enum
-keys between different Python versions. [#633](https://github.com/aio-libs/aiocache/issues/633) -- Padraic Shafer
+keys between different Python versions. [#633](https://github.com/aio-libs/aiocache/issues/633) - Padraic Shafer
 * Improved support for ``build_key(key, namespace)`` [#569](https://github.com/aio-libs/aiocache/issues/569) - Padraic Shafer
     * `BaseCache.build_key` uses `namespace` argument if provided,
     otherwise it uses `self.namespace`.
     * Cache locks use `client.build_key` rather than `client._build_key`.
     * Include examples of using a custom `key_builder` when creating a cache.
     * Warn when decorator parameters are unused because alias takes precedence.
+* Clarify `__init__` params for decorator `multi_cached` [#636](https://github.com/aio-libs/aiocache/issues/636) - Padraic Shafer
 
 ## 0.11.1 (2019-07-31)
 


### PR DESCRIPTION
## Clarify `__init__` params for decorator `multi_cached`

Docstring for `multi_cached` clarifies the use of 
* `keys_from_attr`, 
* `key_builder`, 
* their interaction, and 
* the expected mapping scheme of the dictionary returned by the decorated callable

## Are there changes in behavior for the user?

No, this is an update to documentation only.

## Related issue number

* Resolves #636.
* Might be relevant to #563.

## Checklist

- [X ] I think the code is well written
- [ N/A] Unit tests for the changes exist
- [ X] Documentation reflects the changes
- [X ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
