### PR TITLE
feat: SSL/TLS support for redis cache

### DIFF
--- a/tests/ut/backends/test_redis.py
+++ b/tests/ut/backends/test_redis.py
@@ -34,6 +34,7 @@ class TestRedisBackend:
         "port": 6379,
         "db": 0,
         "password": None,
+        "ssl": False,
         "socket_connect_timeout": None,
         "decode_responses": False,
         "max_connections": None,
@@ -48,11 +49,12 @@ class TestRedisBackend:
         assert redis_backend.port == 6379
         assert redis_backend.db == 0
         assert redis_backend.password is None
+        assert redis_backend.ssl is False
         assert redis_backend.pool_max_size is None
 
     @patch("redis.asyncio.Redis", name="mock_class", autospec=True)
     def test_setup_override(self, mock_class):
-        override = {"db": 2, "password": "pass"}
+        override = {"db": 2, "password": "pass", "ssl": True}
         redis_backend = RedisBackend(**override)
 
         kwargs = self.default_redis_kwargs.copy()
@@ -63,6 +65,7 @@ class TestRedisBackend:
         assert redis_backend.port == 6379
         assert redis_backend.db == 2
         assert redis_backend.password == "pass"
+        assert redis_backend.ssl is True
 
     @patch("redis.asyncio.Redis", name="mock_class", autospec=True)
     def test_setup_casts(self, mock_class):
@@ -71,6 +74,7 @@ class TestRedisBackend:
             "port": "6379",
             "pool_max_size": "10",
             "create_connection_timeout": "1.5",
+            "ssl": "True",
         }
         redis_backend = RedisBackend(**override)
 
@@ -80,6 +84,7 @@ class TestRedisBackend:
             "port": 6379,
             "max_connections": 10,
             "socket_connect_timeout": 1.5,
+            "ssl": True,
         })
         mock_class.assert_called_with(**kwargs)
 
@@ -87,6 +92,7 @@ class TestRedisBackend:
         assert redis_backend.port == 6379
         assert redis_backend.pool_max_size == 10
         assert redis_backend.create_connection_timeout == 1.5
+        assert redis_backend.ssl is True
 
     async def test_get(self, redis):
         redis.client.get.return_value = b"value"


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?
SSL/TLS support for redis cache

## Are there changes in behavior for the user?
`RedisCache` should now have a configuration option for ssl. It also works passing the `ssl` quey param to `from_url`

## Related issue number
#550 

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
