### PR TITLE
Adds LimitLengthPlugin, tests missing.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,14 @@ There are a number of backwards-incompatible changes. These points should help w
   * The ``build_key()`` method must now be defined (this should generally involve calling ``self._str_build_key()`` as a helper).
 
 
+
+
+0.12.1 (2023-06-??)
+===================
+
+* 498.feature - Added the plugin ``LimitLengthPlugin`` that implements limiting the number of records stored in a cache.
+
+
 0.12.0 (2023-01-13)
 ===================
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -59,7 +59,7 @@ In `examples folder <https://github.com/argaen/aiocache/tree/master/examples>`_ 
 - `Sanic, Aiohttp and Tornado <https://github.com/argaen/aiocache/tree/master/examples/frameworks>`_
 - `Python object in Redis <https://github.com/argaen/aiocache/blob/master/examples/python_object.py>`_
 - `Custom serializer for compressing data <https://github.com/argaen/aiocache/blob/master/examples/serializer_class.py>`_
-- `TimingPlugin and HitMissRatioPlugin demos <https://github.com/argaen/aiocache/blob/master/examples/plugins.py>`_
+- `TimingPlugin, HitMissRatioPlugin, and LimitLengthPlugin demos <https://github.com/argaen/aiocache/blob/master/examples/plugins.py>`_
 - `Using marshmallow as a serializer <https://github.com/argaen/aiocache/blob/master/examples/marshmallow_serializer_class.py>`_
 - `Using cached decorator <https://github.com/argaen/aiocache/blob/master/examples/cached_decorator.py>`_.
 - `Using multi_cached decorator <https://github.com/argaen/aiocache/blob/master/examples/multicached_decorator.py>`_.

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -48,3 +48,10 @@ HitMissRatioPlugin
 .. autoclass:: aiocache.plugins.HitMissRatioPlugin
   :members:
   :undoc-members:
+
+LimitLengthPlugin
+------------------
+
+.. autoclass:: aiocache.plugins.LimitLengthPlugin
+  :members:
+  :undoc-members:

--- a/examples/plugins.py
+++ b/examples/plugins.py
@@ -3,7 +3,7 @@ import random
 import logging
 
 from aiocache import Cache
-from aiocache.plugins import HitMissRatioPlugin, TimingPlugin, BasePlugin
+from aiocache.plugins import HitMissRatioPlugin, TimingPlugin, BasePlugin, LimitLengthPlugin
 
 
 logger = logging.getLogger(__name__)
@@ -19,7 +19,7 @@ class MyCustomPlugin(BasePlugin):
 
 
 cache = Cache(
-    plugins=[HitMissRatioPlugin(), TimingPlugin(), MyCustomPlugin()],
+    plugins=[HitMissRatioPlugin(), TimingPlugin(), LimitLengthPlugin(max_length = 4), MyCustomPlugin()],
     namespace="main")
 
 
@@ -28,6 +28,9 @@ async def run():
     await cache.set("b", "2")
     await cache.set("c", "3")
     await cache.set("d", "4")
+    await cache.set("e", "5")
+    await cache.set("f", "6")
+    #entries "a" and "b" above will get dropped because max_length is 4
 
     possible_keys = ["a", "b", "c", "d", "e", "f"]
 

--- a/tests/acceptance/test_plugins.py
+++ b/tests/acceptance/test_plugins.py
@@ -1,6 +1,6 @@
 import pytest
 
-from aiocache.plugins import HitMissRatioPlugin, TimingPlugin
+from aiocache.plugins import HitMissRatioPlugin, TimingPlugin, LimitLengthPlugin
 
 
 class TestHitMissRatioPlugin:
@@ -84,3 +84,19 @@ class TestTimingPlugin:
         assert "get_min" in memory_cache.profiling
         assert "get_total" in memory_cache.profiling
         assert "get_avg" in memory_cache.profiling
+
+class TestLimitLengthPlugin:
+    async def test_limit_length(self, memory_cache):
+        #TODO: I have NO IDEA how to implement this.
+        memory_cache.plugins = [LimitLengthPlugin(max_length=3)]
+        await memory_cache.set('a', 1)
+        assert repr(memory_cache._cache) == "{'a': 1}"
+        await memory_cache.set('b', 2)
+        assert repr(memory_cache._cache) == "{'a': 1, 'b': 2}"
+        await memory_cache.set('c', 3)
+        assert repr(memory_cache._cache) == "{'a': 1, 'b': 2, 'c': 3}"
+        await memory_cache.set('d', 4)
+        assert repr(memory_cache._cache) == "{'b': 2, 'c': 3, 'd': 4}"
+        await memory_cache.clear()
+        await memory_cache.multi_set([('a', -1), ('b', -2), ('c', -3), ('d', -4)])
+        assert repr(memory_cache._cache) == "{'b': -2, 'c': -3, 'd': -4}"

--- a/tests/ut/test_plugins.py
+++ b/tests/ut/test_plugins.py
@@ -79,4 +79,5 @@ class TestHitMissRatioPlugin:
 class TestLimitLengthPlugin:
     async def test_limit_length(self, plugin):
         #TODO: I have NO IDEA how to implement this.
+        #see acceptance/test_plugins.py and examples/plugins.py for some code which might help here.
         return

--- a/tests/ut/test_plugins.py
+++ b/tests/ut/test_plugins.py
@@ -3,7 +3,7 @@ from unittest.mock import create_autospec
 import pytest
 
 from aiocache.base import API, BaseCache
-from aiocache.plugins import BasePlugin, HitMissRatioPlugin, TimingPlugin
+from aiocache.plugins import BasePlugin, HitMissRatioPlugin, TimingPlugin, LimitLengthPlugin
 from ..utils import Keys
 
 
@@ -75,3 +75,8 @@ class TestHitMissRatioPlugin:
         assert client.hit_miss_ratio["hits"] == 2
         assert client.hit_miss_ratio["total"] == 4
         assert client.hit_miss_ratio["hit_ratio"] == 0.5
+
+class TestLimitLengthPlugin:
+    async def test_limit_length(self, plugin):
+        #TODO: I have NO IDEA how to implement this.
+        return


### PR DESCRIPTION
## What do these changes do?

This addresses #498 by adding a plugin that limits the amount of cached records to max_length for memory based caches.
"max_size" is not used since it can be more easily mistaken by a limit in bytes instead of number of records.
After a record is added, if the cache is larger than the set capacity, the records closest to expiration are deleted until the cache returns to the size limit.

## Are there changes in behavior for the user?

Only if the user decides to use it, in which case the user will create the caches using `plugins=[LimitLengthPlugin(max_length=whatever),...]`. It changes nothing otherwise.

## Related issue number

#498

___I have added some code to test basic functionality, but I have no idea how to properly implement the tests___. I will be happy to implement the tests if you can point me in the right direction.


## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
