### PR TITLE
Make aiomcache and redis deps optional for unit tests [WIP]

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,7 @@ universal=1
 max-line-length=100
 
 [tool:pytest]
-addopts = --cov=aiocache --cov=tests/ --cov-report term
+addopts = --cov=aiocache --cov=tests/ --cov-report term --strict-markers
 asyncio_mode = auto
 junit_suite_name = aiohttp_test_suite
 filterwarnings=
@@ -13,6 +13,8 @@ filterwarnings=
 testpaths = tests/
 junit_family=xunit2
 xfail_strict = true
+markers =
+    redis: tests requiring redis backend
 
 [coverage:run]
 branch = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,6 +14,7 @@ testpaths = tests/
 junit_family=xunit2
 xfail_strict = true
 markers =
+    memcached: tests requiring memcached backend
     redis: tests requiring redis backend
 
 [coverage:run]

--- a/tests/acceptance/conftest.py
+++ b/tests/acceptance/conftest.py
@@ -40,6 +40,11 @@ async def memcached_cache():
         await asyncio.gather(*(cache.delete(k) for k in (*Keys, KEY_LOCK)))
 
 
-@pytest.fixture(params=("redis_cache", "memory_cache", "memcached_cache"))
+@pytest.fixture(
+    params=(
+        pytest.param("redis_cache", marks=pytest.mark.redis),
+        "memory_cache",
+        pytest.param("memcached_cache", marks=pytest.mark.memcached),
+    ))
 def cache(request):
     return request.getfixturevalue(request.param)

--- a/tests/acceptance/test_base.py
+++ b/tests/acceptance/test_base.py
@@ -2,9 +2,7 @@ import asyncio
 
 import pytest
 
-from aiocache.backends.memcached import MemcachedCache
 from aiocache.backends.memory import SimpleMemoryCache
-from aiocache.backends.redis import RedisCache
 from aiocache.base import _Conn
 from ..utils import Keys
 
@@ -171,8 +169,11 @@ class TestMemoryCache:
         assert await memory_cache.exists(Keys.KEY, namespace="test") is False
 
 
+@pytest.mark.memcached
 class TestMemcachedCache:
     async def test_accept_explicit_args(self):
+        from aiocache.backends.memcached import MemcachedCache
+
         with pytest.raises(TypeError):
             MemcachedCache(random_attr="wtf")
 
@@ -212,8 +213,11 @@ class TestMemcachedCache:
         assert memcached_cache.client._pool._pool.qsize() == 0
 
 
+@pytest.mark.redis
 class TestRedisCache:
     async def test_accept_explicit_args(self):
+        from aiocache.backends.redis import RedisCache
+
         with pytest.raises(TypeError):
             RedisCache(random_attr="wtf")
 

--- a/tests/acceptance/test_lock.py
+++ b/tests/acceptance/test_lock.py
@@ -127,6 +127,7 @@ class TestMemoryRedLock:
         assert await lock.__aexit__("exc_type", "exc_value", "traceback") is None
 
 
+@pytest.mark.redis
 class TestRedisRedLock:
     @pytest.fixture
     def lock(self, redis_cache):
@@ -160,6 +161,7 @@ class TestRedisRedLock:
         assert await lock.__aexit__("exc_type", "exc_value", "traceback") is None
 
 
+@pytest.mark.memcached
 class TestMemcachedRedLock:
     @pytest.fixture
     def lock(self, memcached_cache):
@@ -255,6 +257,7 @@ class TestMemoryOptimisticLock:
         assert await memory_cache.get(Keys.KEY) is None
 
 
+@pytest.mark.redis
 class TestRedisOptimisticLock:
     @pytest.fixture
     def lock(self, redis_cache):

--- a/tests/ut/conftest.py
+++ b/tests/ut/conftest.py
@@ -5,8 +5,6 @@ from unittest.mock import create_autospec, patch
 import pytest
 
 from aiocache import caches
-from aiocache.backends.memcached import MemcachedCache
-from aiocache.backends.redis import RedisCache
 from aiocache.plugins import BasePlugin
 from ..utils import AbstractBaseCache, ConcreteBaseCache
 
@@ -61,11 +59,15 @@ def base_cache():
 
 @pytest.fixture
 async def redis_cache():
+    from aiocache.backends.redis import RedisCache
+
     async with RedisCache() as cache:
         yield cache
 
 
 @pytest.fixture
 async def memcached_cache():
+    from aiocache.backends.memcached import MemcachedCache
+
     async with MemcachedCache() as cache:
         yield cache

--- a/tests/ut/test_factory.py
+++ b/tests/ut/test_factory.py
@@ -29,10 +29,12 @@ else:
     CACHE_NAMES.append(Cache.REDIS.NAME)
 
 
+@pytest.mark.redis
 def test_class_from_string():
     assert _class_from_string("aiocache.RedisCache") == RedisCache
 
 
+@pytest.mark.redis
 def test_create_simple_cache():
     redis = _create_cache(RedisCache, endpoint="127.0.0.10", port=6378)
 
@@ -42,15 +44,15 @@ def test_create_simple_cache():
 
 
 def test_create_cache_with_everything():
-    redis = _create_cache(
-        RedisCache,
+    cache = _create_cache(
+        SimpleMemoryCache,
         serializer={"class": PickleSerializer, "encoding": "encoding"},
         plugins=[{"class": "aiocache.plugins.TimingPlugin"}],
     )
 
-    assert isinstance(redis.serializer, PickleSerializer)
-    assert redis.serializer.encoding == "encoding"
-    assert isinstance(redis.plugins[0], TimingPlugin)
+    assert isinstance(cache.serializer, PickleSerializer)
+    assert cache.serializer.encoding == "encoding"
+    assert isinstance(cache.plugins[0], TimingPlugin)
 
 
 class TestCache:
@@ -177,6 +179,7 @@ class TestCacheHandler:
     def test_create_not_reuse(self):
         assert caches.create("default") is not caches.create("default")
 
+    @pytest.mark.redis
     def test_create_extra_args(self):
         caches.set_config(
             {
@@ -193,6 +196,7 @@ class TestCacheHandler:
         assert cache.endpoint == "127.0.0.10"
         assert cache.db == 10
 
+    @pytest.mark.redis
     def test_retrieve_cache(self):
         caches.set_config(
             {
@@ -222,6 +226,7 @@ class TestCacheHandler:
         assert cache.serializer.encoding == "encoding"
         assert len(cache.plugins) == 2
 
+    @pytest.mark.redis
     def test_retrieve_cache_new_instance(self):
         caches.set_config(
             {
@@ -249,6 +254,7 @@ class TestCacheHandler:
         assert cache.serializer.encoding == "encoding"
         assert len(cache.plugins) == 2
 
+    @pytest.mark.redis
     def test_multiple_caches(self):
         caches.set_config(
             {
@@ -343,6 +349,7 @@ class TestCacheHandler:
                 }
             )
 
+    @pytest.mark.redis
     def test_ensure_plugins_order(self):
         caches.set_config(
             {

--- a/tests/ut/test_factory.py
+++ b/tests/ut/test_factory.py
@@ -3,17 +3,30 @@ from unittest.mock import Mock, patch
 import pytest
 
 from aiocache import AIOCACHE_CACHES, Cache, caches
-from aiocache.backends.memcached import MemcachedCache
 from aiocache.backends.memory import SimpleMemoryCache
-from aiocache.backends.redis import RedisCache
 from aiocache.exceptions import InvalidCacheType
 from aiocache.factory import _class_from_string, _create_cache
 from aiocache.plugins import HitMissRatioPlugin, TimingPlugin
 from aiocache.serializers import JsonSerializer, PickleSerializer
 
-assert Cache.REDIS is not None
-assert Cache.MEMCACHED is not None
-CACHE_NAMES = (Cache.MEMORY.NAME, Cache.REDIS.NAME, Cache.MEMCACHED.NAME)
+
+CACHE_NAMES = [Cache.MEMORY.NAME]
+
+try:
+    from aiocache.backends.memcached import MemcachedCache
+except ImportError:
+    MemcachedCache = None
+else:
+    assert Cache.MEMCACHED is not None
+    CACHE_NAMES.append(Cache.MEMCACHED.NAME)
+
+try:
+    from aiocache.backends.redis import RedisCache
+except ImportError:
+    RedisCache = None
+else:
+    assert Cache.REDIS is not None
+    CACHE_NAMES.append(Cache.REDIS.NAME)
 
 
 def test_class_from_string():


### PR DESCRIPTION
## What do these changes do?

Make it possible to run a subset of unit tests without aiomcache and/or redis installed.  This makes testing easier for distributions that aren't planning to use these backends.

## Are there changes in behavior for the user?

The changes are limited to the test suite.

## Related issue number

#724 

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
