### PR TITLE
Change RedisBackend to accept Redis client directly

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,7 @@ Migration instructions
 
 There are a number of backwards-incompatible changes. These points should help with migrating from an older release:
 
+* ``RedisBackend`` now expects a ``redis.Redis`` instance as an argument, instead of creating one internally from keyword arguments.
 * The ``key_builder`` parameter for caches now expects a callback which accepts 2 strings and returns a string in all cache implementations, making the builders simpler and interchangeable.
 * The ``key`` parameter has been removed from the ``cached`` decorator. The behaviour can be easily reimplemented with ``key_builder=lambda *a, **kw: "foo"``
 * When using the ``key_builder`` parameter in ``@multicached``, the function will now return the original, unmodified keys, only using the transformed keys in the cache (this has always been the documented behaviour, but not the implemented behaviour).

--- a/aiocache/backends/memcached.py
+++ b/aiocache/backends/memcached.py
@@ -8,13 +8,13 @@ from aiocache.serializers import JsonSerializer
 
 
 class MemcachedBackend(BaseCache[bytes]):
-    def __init__(self, endpoint="127.0.0.1", port=11211, pool_size=2, **kwargs):
+    def __init__(self, host="127.0.0.1", port=11211, pool_size=2, **kwargs):
         super().__init__(**kwargs)
-        self.endpoint = endpoint
+        self.host = host
         self.port = port
         self.pool_size = int(pool_size)
         self.client = aiomcache.Client(
-            self.endpoint, self.port, pool_size=self.pool_size
+            self.host, self.port, pool_size=self.pool_size
         )
 
     async def _get(self, key, encoding="utf-8", _conn=None):
@@ -153,4 +153,4 @@ class MemcachedCache(MemcachedBackend):
         return {}
 
     def __repr__(self):  # pragma: no cover
-        return "MemcachedCache ({}:{})".format(self.endpoint, self.port)
+        return "MemcachedCache ({}:{})".format(self.host, self.port)

--- a/aiocache/backends/redis.py
+++ b/aiocache/backends/redis.py
@@ -1,5 +1,4 @@
 import itertools
-import warnings
 from typing import Any, Callable, Optional, TYPE_CHECKING
 
 import redis.asyncio as redis
@@ -38,41 +37,11 @@ class RedisBackend(BaseCache[str]):
 
     def __init__(
         self,
-        endpoint="127.0.0.1",
-        port=6379,
-        db=0,
-        password=None,
-        pool_min_size=_NOT_SET,
-        pool_max_size=None,
-        create_connection_timeout=None,
+        client,
         **kwargs,
     ):
         super().__init__(**kwargs)
-        if pool_min_size is not _NOT_SET:
-            warnings.warn(
-                "Parameter 'pool_min_size' is deprecated since aiocache 0.12",
-                DeprecationWarning, stacklevel=2
-            )
-
-        self.endpoint = endpoint
-        self.port = int(port)
-        self.db = int(db)
-        self.password = password
-        # TODO: Remove int() call some time after adding type annotations.
-        self.pool_max_size = None if pool_max_size is None else int(pool_max_size)
-        self.create_connection_timeout = (
-            float(create_connection_timeout) if create_connection_timeout else None
-        )
-
-        # NOTE: decoding can't be controlled on API level after switching to
-        # redis, we need to disable decoding on global/connection level
-        # (decode_responses=False), because some of the values are saved as
-        # bytes directly, like pickle serialized values, which may raise an
-        # exception when decoded with 'utf-8'.
-        self.client = redis.Redis(host=self.endpoint, port=self.port, db=self.db,
-                                  password=self.password, decode_responses=False,
-                                  socket_connect_timeout=self.create_connection_timeout,
-                                  max_connections=self.pool_max_size)
+        self.client = client
 
     async def _get(self, key, encoding="utf-8", _conn=None):
         value = await self.client.get(key)
@@ -175,9 +144,6 @@ class RedisBackend(BaseCache[str]):
     async def _redlock_release(self, key, value):
         return await self._raw("eval", self.RELEASE_SCRIPT, 1, key, value)
 
-    async def _close(self, *args, _conn=None, **kwargs):
-        await self.client.close()
-
     def build_key(self, key: str, namespace: Optional[str] = None) -> str:
         return self._str_build_key(key, namespace)
 
@@ -196,24 +162,21 @@ class RedisCache(RedisBackend):
         the backend. Default is an empty string, "".
     :param timeout: int or float in seconds specifying maximum timeout for the operations to last.
         By default its 5.
-    :param endpoint: str with the endpoint to connect to. Default is "127.0.0.1".
-    :param port: int with the port to connect to. Default is 6379.
-    :param db: int indicating database to use. Default is 0.
-    :param password: str indicating password to use. Default is None.
-    :param pool_max_size: int maximum pool size for the redis connections pool. Default is None.
-    :param create_connection_timeout: int timeout for the creation of connection. Default is None
+    :param client: redis.Redis which is an active client for working with redis
     """
 
     NAME = "redis"
 
     def __init__(
         self,
+        client: redis.Redis,
         serializer: Optional["BaseSerializer"] = None,
         namespace: str = "",
         key_builder: Callable[[str, str], str] = lambda k, ns: f"{ns}:{k}" if ns else k,
         **kwargs: Any,
     ):
         super().__init__(
+            client=client,
             serializer=serializer or JsonSerializer(),
             namespace=namespace,
             key_builder=key_builder,
@@ -237,4 +200,5 @@ class RedisCache(RedisBackend):
         return options
 
     def __repr__(self):  # pragma: no cover
-        return "RedisCache ({}:{})".format(self.endpoint, self.port)
+        connection_kwargs = self.client.connection_pool.connection_kwargs
+        return "RedisCache ({}:{})".format(connection_kwargs['host'], connection_kwargs['port'])

--- a/aiocache/backends/redis.py
+++ b/aiocache/backends/redis.py
@@ -37,7 +37,7 @@ class RedisBackend(BaseCache[str]):
 
     def __init__(
         self,
-        client,
+        client: redis.Redis,
         **kwargs,
     ):
         super().__init__(**kwargs)

--- a/aiocache/backends/redis.py
+++ b/aiocache/backends/redis.py
@@ -41,6 +41,14 @@ class RedisBackend(BaseCache[str]):
         **kwargs,
     ):
         super().__init__(**kwargs)
+
+        # NOTE: decoding can't be controlled on API level after switching to
+        # redis, we need to disable decoding on global/connection level
+        # (decode_responses=False), because some of the values are saved as
+        # bytes directly, like pickle serialized values, which may raise an
+        # exception when decoded with 'utf-8'.
+        if client.connection_pool.connection_kwargs['decode_responses']:
+            raise ValueError("redis client must be constructed with decode_responses set to False")
         self.client = client
 
     async def _get(self, key, encoding="utf-8", _conn=None):

--- a/aiocache/factory.py
+++ b/aiocache/factory.py
@@ -3,7 +3,7 @@ import urllib
 from copy import deepcopy
 from typing import Dict
 
-import redis
+import redis.asyncio as redis
 
 from aiocache import AIOCACHE_CACHES
 from aiocache.base import BaseCache
@@ -230,7 +230,7 @@ class CacheHandler:
                 },
                 'redis_alt': {
                     'cache': "aiocache.RedisCache",
-                    'endpoint': "127.0.0.10",
+                    'host': "127.0.0.10",
                     'port': 6378,
                     'serializer': {
                         'class': "aiocache.serializers.PickleSerializer"

--- a/aiocache/factory.py
+++ b/aiocache/factory.py
@@ -1,4 +1,3 @@
-import copy
 import logging
 import urllib
 from copy import deepcopy
@@ -21,7 +20,7 @@ def _class_from_string(class_path):
 
 
 def _create_cache(cache, serializer=None, plugins=None, **kwargs):
-    kwargs = copy.deepcopy(kwargs)
+    kwargs = deepcopy(kwargs)
     if serializer is not None:
         cls = serializer.pop("class")
         cls = _class_from_string(cls) if isinstance(cls, str) else cls

--- a/aiocache/factory.py
+++ b/aiocache/factory.py
@@ -1,13 +1,15 @@
 import logging
 import urllib
+from contextlib import suppress
 from copy import deepcopy
 from typing import Dict
-
-import redis.asyncio as redis
 
 from aiocache import AIOCACHE_CACHES
 from aiocache.base import BaseCache
 from aiocache.exceptions import InvalidCacheType
+
+with suppress(ImportError):
+    import redis.asyncio as redis
 
 
 logger = logging.getLogger(__name__)

--- a/aiocache/factory.py
+++ b/aiocache/factory.py
@@ -1,3 +1,4 @@
+import copy
 import logging
 import urllib
 from copy import deepcopy
@@ -20,6 +21,7 @@ def _class_from_string(class_path):
 
 
 def _create_cache(cache, serializer=None, plugins=None, **kwargs):
+    kwargs = copy.deepcopy(kwargs)
     if serializer is not None:
         cls = serializer.pop("class")
         cls = _class_from_string(cls) if isinstance(cls, str) else cls

--- a/examples/cached_alias_config.py
+++ b/examples/cached_alias_config.py
@@ -57,7 +57,7 @@ async def test_alias():
     await default_cache()
     await alt_cache()
 
-    cache = Cache(Cache.REDIS, client=redis.Redis() )
+    cache = Cache(Cache.REDIS, client=redis.Redis())
     await cache.delete("key")
     await cache.close()
 

--- a/examples/cached_alias_config.py
+++ b/examples/cached_alias_config.py
@@ -14,9 +14,9 @@ caches.set_config({
     },
     'redis_alt': {
         'cache': "aiocache.RedisCache",
-        'host': "127.0.0.1",
+        "host": "127.0.0.1",
         'port': 6379,
-        'socket_connect_timeout': 1,
+        "socket_connect_timeout": 1,
         'serializer': {
             'class': "aiocache.serializers.PickleSerializer"
         },
@@ -47,9 +47,9 @@ async def alt_cache():
     assert isinstance(cache, Cache.REDIS)
     assert isinstance(cache.serializer, PickleSerializer)
     assert len(cache.plugins) == 2
-    assert cache.client.connection_pool.connection_kwargs['host'] == "127.0.0.1"
-    assert cache.client.connection_pool.connection_kwargs['socket_connect_timeout'] == 1
-    assert cache.client.connection_pool.connection_kwargs['port'] == 6379
+    assert cache.client.connection_pool.connection_kwargs["host"] == "127.0.0.1"
+    assert cache.client.connection_pool.connection_kwargs["socket_connect_timeout"] == 1
+    assert cache.client.connection_pool.connection_kwargs["port"] == 6379
     await cache.close()
 
 

--- a/examples/cached_alias_config.py
+++ b/examples/cached_alias_config.py
@@ -47,9 +47,10 @@ async def alt_cache():
     assert isinstance(cache, Cache.REDIS)
     assert isinstance(cache.serializer, PickleSerializer)
     assert len(cache.plugins) == 2
-    assert cache.client.connection_pool.connection_kwargs["host"] == "127.0.0.1"
-    assert cache.client.connection_pool.connection_kwargs["socket_connect_timeout"] == 1
-    assert cache.client.connection_pool.connection_kwargs["port"] == 6379
+    connection_args = cache.client.connection_pool.connection_kwargs
+    assert connection_args["host"] == "127.0.0.1"
+    assert connection_args["socket_connect_timeout"] == 1
+    assert connection_args["port"] == 6379
     await cache.close()
 
 

--- a/examples/cached_alias_config.py
+++ b/examples/cached_alias_config.py
@@ -4,7 +4,6 @@ import redis.asyncio as redis
 
 from aiocache import caches, Cache
 from aiocache.serializers import StringSerializer, PickleSerializer
-from examples.conftest import redis_kwargs_for_test
 
 caches.set_config({
     'default': {
@@ -58,7 +57,7 @@ async def test_alias():
     await default_cache()
     await alt_cache()
 
-    cache = Cache(Cache.REDIS, client=redis.Redis(**redis_kwargs_for_test()) )
+    cache = Cache(Cache.REDIS, client=redis.Redis() )
     await cache.delete("key")
     await cache.close()
 

--- a/examples/cached_decorator.py
+++ b/examples/cached_decorator.py
@@ -1,22 +1,29 @@
 import asyncio
 
 from collections import namedtuple
+import redis.asyncio as redis
 
 from aiocache import cached, Cache
 from aiocache.serializers import PickleSerializer
+from examples.conftest import redis_kwargs_for_test
 
 Result = namedtuple('Result', "content, status")
 
 
 @cached(
     ttl=10, cache=Cache.REDIS, key_builder=lambda *args, **kw: "key",
-    serializer=PickleSerializer(), port=6379, namespace="main")
+    serializer=PickleSerializer(), namespace="main", client = redis.Redis(
+        host="127.0.0.1",
+        port=6379,
+        db=0,
+        decode_responses=False,
+    ))
 async def cached_call():
     return Result("content", 200)
 
 
 async def test_cached():
-    async with Cache(Cache.REDIS, endpoint="127.0.0.1", port=6379, namespace="main") as cache:
+    async with Cache(Cache.REDIS, namespace="main", client=redis.Redis(**redis_kwargs_for_test())) as cache:
         await cached_call()
         exists = await cache.exists("key")
         assert exists is True

--- a/examples/cached_decorator.py
+++ b/examples/cached_decorator.py
@@ -5,25 +5,19 @@ import redis.asyncio as redis
 
 from aiocache import cached, Cache
 from aiocache.serializers import PickleSerializer
-from examples.conftest import redis_kwargs_for_test
 
 Result = namedtuple('Result', "content, status")
 
 
 @cached(
     ttl=10, cache=Cache.REDIS, key_builder=lambda *args, **kw: "key",
-    serializer=PickleSerializer(), namespace="main", client = redis.Redis(
-        host="127.0.0.1",
-        port=6379,
-        db=0,
-        decode_responses=False,
-    ))
+    serializer=PickleSerializer(), namespace="main", client = redis.Redis())
 async def cached_call():
     return Result("content", 200)
 
 
 async def test_cached():
-    async with Cache(Cache.REDIS, namespace="main", client=redis.Redis(**redis_kwargs_for_test())) as cache:
+    async with Cache(Cache.REDIS, namespace="main", client=redis.Redis()) as cache:
         await cached_call()
         exists = await cache.exists("key")
         assert exists is True

--- a/examples/cached_decorator.py
+++ b/examples/cached_decorator.py
@@ -11,7 +11,7 @@ Result = namedtuple('Result', "content, status")
 
 @cached(
     ttl=10, cache=Cache.REDIS, key_builder=lambda *args, **kw: "key",
-    serializer=PickleSerializer(), namespace="main", client = redis.Redis())
+    serializer=PickleSerializer(), namespace="main", client=redis.Redis())
 async def cached_call():
     return Result("content", 200)
 

--- a/examples/conftest.py
+++ b/examples/conftest.py
@@ -1,0 +1,9 @@
+def redis_kwargs_for_test():
+    return dict(
+        host="127.0.0.1",
+        port=6379,
+        db=0,
+        password=None,
+        decode_responses=False,
+        socket_connect_timeout=None,
+    )

--- a/examples/conftest.py
+++ b/examples/conftest.py
@@ -1,9 +1,0 @@
-def redis_kwargs_for_test():
-    return dict(
-        host="127.0.0.1",
-        port=6379,
-        db=0,
-        password=None,
-        decode_responses=False,
-        socket_connect_timeout=None,
-    )

--- a/examples/multicached_decorator.py
+++ b/examples/multicached_decorator.py
@@ -1,6 +1,9 @@
 import asyncio
 
+import redis.asyncio as redis
+
 from aiocache import multi_cached, Cache
+from examples.conftest import redis_kwargs_for_test
 
 DICT = {
     'a': "Z",
@@ -9,18 +12,19 @@ DICT = {
     'd': "W"
 }
 
+cache = Cache(Cache.REDIS, namespace="main", client=redis.Redis(**redis_kwargs_for_test()))
 
-@multi_cached("ids", cache=Cache.REDIS, namespace="main")
+
+@multi_cached("ids", cache=Cache.REDIS, namespace="main", client=cache.client)
 async def multi_cached_ids(ids=None):
     return {id_: DICT[id_] for id_ in ids}
 
 
-@multi_cached("keys", cache=Cache.REDIS, namespace="main")
+@multi_cached("keys", cache=Cache.REDIS, namespace="main", client=cache.client)
 async def multi_cached_keys(keys=None):
     return {id_: DICT[id_] for id_ in keys}
 
 
-cache = Cache(Cache.REDIS, endpoint="127.0.0.1", port=6379, namespace="main")
 
 
 async def test_multi_cached():

--- a/examples/multicached_decorator.py
+++ b/examples/multicached_decorator.py
@@ -3,7 +3,6 @@ import asyncio
 import redis.asyncio as redis
 
 from aiocache import multi_cached, Cache
-from examples.conftest import redis_kwargs_for_test
 
 DICT = {
     'a': "Z",
@@ -12,7 +11,7 @@ DICT = {
     'd': "W"
 }
 
-cache = Cache(Cache.REDIS, namespace="main", client=redis.Redis(**redis_kwargs_for_test()))
+cache = Cache(Cache.REDIS, namespace="main", client=redis.Redis())
 
 
 @multi_cached("ids", cache=Cache.REDIS, namespace="main", client=cache.client)

--- a/examples/multicached_decorator.py
+++ b/examples/multicached_decorator.py
@@ -24,8 +24,6 @@ async def multi_cached_keys(keys=None):
     return {id_: DICT[id_] for id_ in keys}
 
 
-
-
 async def test_multi_cached():
     await multi_cached_ids(ids=("a", "b"))
     await multi_cached_ids(ids=("a", "c"))

--- a/examples/optimistic_lock.py
+++ b/examples/optimistic_lock.py
@@ -2,12 +2,14 @@ import asyncio
 import logging
 import random
 
+import redis.asyncio as redis
+
 from aiocache import Cache
 from aiocache.lock import OptimisticLock, OptimisticLockError
-
+from examples.conftest import redis_kwargs_for_test
 
 logger = logging.getLogger(__name__)
-cache = Cache(Cache.REDIS, endpoint='127.0.0.1', port=6379, namespace='main')
+cache = Cache(Cache.REDIS, namespace="main", client=redis.Redis(**redis_kwargs_for_test()))
 
 
 async def expensive_function():

--- a/examples/optimistic_lock.py
+++ b/examples/optimistic_lock.py
@@ -6,10 +6,9 @@ import redis.asyncio as redis
 
 from aiocache import Cache
 from aiocache.lock import OptimisticLock, OptimisticLockError
-from examples.conftest import redis_kwargs_for_test
 
 logger = logging.getLogger(__name__)
-cache = Cache(Cache.REDIS, namespace="main", client=redis.Redis(**redis_kwargs_for_test()))
+cache = Cache(Cache.REDIS, namespace="main", client=redis.Redis())
 
 
 async def expensive_function():

--- a/examples/python_object.py
+++ b/examples/python_object.py
@@ -1,12 +1,15 @@
 import asyncio
 
 from collections import namedtuple
+import redis.asyncio as redis
+
+
 from aiocache import Cache
 from aiocache.serializers import PickleSerializer
-
+from examples.conftest import redis_kwargs_for_test
 
 MyObject = namedtuple("MyObject", ["x", "y"])
-cache = Cache(Cache.REDIS, serializer=PickleSerializer(), namespace="main")
+cache = Cache(Cache.REDIS, serializer=PickleSerializer(), namespace="main", client=redis.Redis(**redis_kwargs_for_test()))
 
 
 async def complex_object():

--- a/examples/python_object.py
+++ b/examples/python_object.py
@@ -6,10 +6,9 @@ import redis.asyncio as redis
 
 from aiocache import Cache
 from aiocache.serializers import PickleSerializer
-from examples.conftest import redis_kwargs_for_test
 
 MyObject = namedtuple("MyObject", ["x", "y"])
-cache = Cache(Cache.REDIS, serializer=PickleSerializer(), namespace="main", client=redis.Redis(**redis_kwargs_for_test()))
+cache = Cache(Cache.REDIS, serializer=PickleSerializer(), namespace="main", client=redis.Redis())
 
 
 async def complex_object():

--- a/examples/redlock.py
+++ b/examples/redlock.py
@@ -7,7 +7,7 @@ from aiocache import Cache
 from aiocache.lock import RedLock
 
 logger = logging.getLogger(__name__)
-cache = Cache(Cache.REDIS, namespace='main', client=redis.Redis())
+cache = Cache(Cache.REDIS, namespace="main", client=redis.Redis())
 
 
 async def expensive_function():

--- a/examples/redlock.py
+++ b/examples/redlock.py
@@ -1,12 +1,14 @@
 import asyncio
 import logging
 
+import redis.asyncio as redis
+
 from aiocache import Cache
 from aiocache.lock import RedLock
-
+from examples.conftest import redis_kwargs_for_test
 
 logger = logging.getLogger(__name__)
-cache = Cache(Cache.REDIS, endpoint='127.0.0.1', port=6379, namespace='main')
+cache = Cache(Cache.REDIS, namespace='main', client=redis.Redis(**redis_kwargs_for_test()))
 
 
 async def expensive_function():

--- a/examples/redlock.py
+++ b/examples/redlock.py
@@ -5,10 +5,9 @@ import redis.asyncio as redis
 
 from aiocache import Cache
 from aiocache.lock import RedLock
-from examples.conftest import redis_kwargs_for_test
 
 logger = logging.getLogger(__name__)
-cache = Cache(Cache.REDIS, namespace='main', client=redis.Redis(**redis_kwargs_for_test()))
+cache = Cache(Cache.REDIS, namespace='main', client=redis.Redis())
 
 
 async def expensive_function():

--- a/examples/serializer_class.py
+++ b/examples/serializer_class.py
@@ -5,7 +5,6 @@ import redis.asyncio as redis
 
 from aiocache import Cache
 from aiocache.serializers import BaseSerializer
-from examples.conftest import redis_kwargs_for_test
 
 
 class CompressionSerializer(BaseSerializer):
@@ -28,7 +27,7 @@ class CompressionSerializer(BaseSerializer):
         return decompressed
 
 
-cache = Cache(Cache.REDIS, serializer=CompressionSerializer(), namespace="main", client=redis.Redis(**redis_kwargs_for_test()) )
+cache = Cache(Cache.REDIS, serializer=CompressionSerializer(), namespace="main", client=redis.Redis())
 
 
 async def serializer():

--- a/examples/serializer_class.py
+++ b/examples/serializer_class.py
@@ -1,8 +1,11 @@
 import asyncio
 import zlib
 
+import redis.asyncio as redis
+
 from aiocache import Cache
 from aiocache.serializers import BaseSerializer
+from examples.conftest import redis_kwargs_for_test
 
 
 class CompressionSerializer(BaseSerializer):
@@ -25,7 +28,7 @@ class CompressionSerializer(BaseSerializer):
         return decompressed
 
 
-cache = Cache(Cache.REDIS, serializer=CompressionSerializer(), namespace="main")
+cache = Cache(Cache.REDIS, serializer=CompressionSerializer(), namespace="main", client=redis.Redis(**redis_kwargs_for_test()) )
 
 
 async def serializer():

--- a/examples/serializer_function.py
+++ b/examples/serializer_function.py
@@ -1,8 +1,11 @@
 import asyncio
 import json
 
+import redis.asyncio as redis
+
 from marshmallow import Schema, fields, post_load
 from aiocache import Cache
+from examples.conftest import redis_kwargs_for_test
 
 
 class MyType:
@@ -28,7 +31,7 @@ def loads(value):
     return MyTypeSchema().loads(value)
 
 
-cache = Cache(Cache.REDIS, namespace="main")
+cache = Cache(Cache.REDIS, namespace="main", client=redis.Redis(**redis_kwargs_for_test()))
 
 
 async def serializer_function():

--- a/examples/serializer_function.py
+++ b/examples/serializer_function.py
@@ -5,7 +5,6 @@ import redis.asyncio as redis
 
 from marshmallow import Schema, fields, post_load
 from aiocache import Cache
-from examples.conftest import redis_kwargs_for_test
 
 
 class MyType:
@@ -31,7 +30,7 @@ def loads(value):
     return MyTypeSchema().loads(value)
 
 
-cache = Cache(Cache.REDIS, namespace="main", client=redis.Redis(**redis_kwargs_for_test()))
+cache = Cache(Cache.REDIS, namespace="main", client=redis.Redis())
 
 
 async def serializer_function():

--- a/examples/simple_redis.py
+++ b/examples/simple_redis.py
@@ -2,8 +2,11 @@ import asyncio
 
 from aiocache import Cache
 
+import redis.asyncio as redis
 
-cache = Cache(Cache.REDIS, endpoint="127.0.0.1", port=6379, namespace="main")
+from examples.conftest import redis_kwargs_for_test
+
+cache = Cache(Cache.REDIS, namespace="main" , client=redis.Redis(**redis_kwargs_for_test()) )
 
 
 async def redis():

--- a/examples/simple_redis.py
+++ b/examples/simple_redis.py
@@ -4,9 +4,7 @@ from aiocache import Cache
 
 import redis.asyncio as redis
 
-from examples.conftest import redis_kwargs_for_test
-
-cache = Cache(Cache.REDIS, namespace="main" , client=redis.Redis(**redis_kwargs_for_test()) )
+cache = Cache(Cache.REDIS, namespace="main" , client=redis.Redis() )
 
 
 async def redis():

--- a/examples/simple_redis.py
+++ b/examples/simple_redis.py
@@ -4,7 +4,7 @@ from aiocache import Cache
 
 import redis.asyncio as redis
 
-cache = Cache(Cache.REDIS, namespace="main" , client=redis.Redis() )
+cache = Cache(Cache.REDIS, namespace="main", client=redis.Redis())
 
 
 async def redis():

--- a/tests/acceptance/conftest.py
+++ b/tests/acceptance/conftest.py
@@ -20,8 +20,8 @@ def reset_caches():
 
 
 @pytest.fixture
-async def redis_cache():
-    async with Cache(Cache.REDIS, namespace="test") as cache:
+async def redis_cache(redis_client):
+    async with Cache(Cache.REDIS, namespace="test", client=redis_client) as cache:
         yield cache
         await asyncio.gather(*(cache.delete(k) for k in (*Keys, KEY_LOCK)))
 

--- a/tests/acceptance/test_factory.py
+++ b/tests/acceptance/test_factory.py
@@ -18,15 +18,15 @@ class TestCache:
         from aiocache.backends.redis import RedisCache
 
         url = ("redis://endpoint:1000/0/?password=pass"
-               + "&pool_max_size=50&create_connection_timeout=20")
+               + "&max_connections=50&socket_connect_timeout=20")
 
         async with Cache.from_url(url) as cache:
             assert isinstance(cache, RedisCache)
-            assert cache.endpoint == "endpoint"
-            assert cache.port == 1000
-            assert cache.password == "pass"
-            assert cache.pool_max_size == 50
-            assert cache.create_connection_timeout == 20
+            assert cache.client.connection_pool.connection_kwargs['host'] == "endpoint"
+            assert cache.client.connection_pool.connection_kwargs['port'] == 1000
+            assert cache.client.connection_pool.connection_kwargs['password'] == "pass"
+            assert cache.client.connection_pool.max_connections == 50
+            assert cache.client.connection_pool.connection_kwargs['socket_connect_timeout'] == 20
 
     @pytest.mark.memcached
     async def test_from_url_memcached(self):
@@ -36,7 +36,7 @@ class TestCache:
 
         async with Cache.from_url(url) as cache:
             assert isinstance(cache, MemcachedCache)
-            assert cache.endpoint == "endpoint"
+            assert cache.host == "endpoint"
             assert cache.port == 1000
             assert cache.pool_size == 10
 

--- a/tests/acceptance/test_factory.py
+++ b/tests/acceptance/test_factory.py
@@ -22,11 +22,11 @@ class TestCache:
 
         async with Cache.from_url(url) as cache:
             assert isinstance(cache, RedisCache)
-            assert cache.client.connection_pool.connection_kwargs['host'] == "endpoint"
-            assert cache.client.connection_pool.connection_kwargs['port'] == 1000
-            assert cache.client.connection_pool.connection_kwargs['password'] == "pass"
+            assert cache.client.connection_pool.connection_kwargs["host"] == "endpoint"
+            assert cache.client.connection_pool.connection_kwargs["port"] == 1000
+            assert cache.client.connection_pool.connection_kwargs["password"] == "pass"
             assert cache.client.connection_pool.max_connections == 50
-            assert cache.client.connection_pool.connection_kwargs['socket_connect_timeout'] == 20
+            assert cache.client.connection_pool.connection_kwargs["socket_connect_timeout"] == 20
 
     @pytest.mark.memcached
     async def test_from_url_memcached(self):

--- a/tests/acceptance/test_factory.py
+++ b/tests/acceptance/test_factory.py
@@ -11,7 +11,7 @@ class TestCache:
 
     def test_from_url_memory_no_endpoint(self):
         with pytest.raises(TypeError):
-            Cache.from_url("memory://endpoint:10")
+            Cache.from_url("memory://host:10")
 
     @pytest.mark.redis
     async def test_from_url_redis(self):

--- a/tests/acceptance/test_factory.py
+++ b/tests/acceptance/test_factory.py
@@ -22,11 +22,12 @@ class TestCache:
 
         async with Cache.from_url(url) as cache:
             assert isinstance(cache, RedisCache)
-            assert cache.client.connection_pool.connection_kwargs["host"] == "endpoint"
-            assert cache.client.connection_pool.connection_kwargs["port"] == 1000
-            assert cache.client.connection_pool.connection_kwargs["password"] == "pass"
+            connection_args = cache.client.connection_pool.connection_kwargs
+            assert connection_args["host"] == "endpoint"
+            assert connection_args["port"] == 1000
+            assert connection_args["password"] == "pass"
             assert cache.client.connection_pool.max_connections == 50
-            assert cache.client.connection_pool.connection_kwargs["socket_connect_timeout"] == 20
+            assert connection_args["socket_connect_timeout"] == 20
 
     @pytest.mark.memcached
     async def test_from_url_memcached(self):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,16 +7,20 @@ def max_conns():
     return None
 
 
+@pytest.fixture()
+def decode_responses():
+    return False
+
+
 @pytest.fixture
-async def redis_client(max_conns):
-    r = redis.Redis(
+async def redis_client(max_conns, decode_responses):
+    async with redis.Redis(
         host="127.0.0.1",
         port=6379,
         db=0,
         password=None,
-        decode_responses=False,
+        decode_responses=decode_responses,
         socket_connect_timeout=None,
         max_connections=max_conns
-    )
-    yield r
-    await r.close()
+    ) as r:
+        yield r

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,4 @@
 import pytest
-import redis.asyncio as redis
 
 
 @pytest.fixture()
@@ -14,6 +13,8 @@ def decode_responses():
 
 @pytest.fixture
 async def redis_client(max_conns, decode_responses):
+    import redis.asyncio as redis
+
     async with redis.Redis(
         host="127.0.0.1",
         port=6379,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,22 @@
+import pytest
+import redis.asyncio as redis
+
+
+@pytest.fixture()
+def max_conns():
+    return None
+
+
+@pytest.fixture
+async def redis_client(max_conns):
+    r = redis.Redis(
+        host="127.0.0.1",
+        port=6379,
+        db=0,
+        password=None,
+        decode_responses=False,
+        socket_connect_timeout=None,
+        max_connections=max_conns
+    )
+    yield r
+    await r.close()

--- a/tests/performance/conftest.py
+++ b/tests/performance/conftest.py
@@ -4,7 +4,7 @@ from aiocache import Cache
 
 
 @pytest.fixture
-@pytest.mark.parametrize('max_conns', 1)
+@pytest.mark.parametrize("max_conns", 1)
 async def redis_cache(redis_client):
     # redis connection pool raises ConnectionError but doesn't wait for conn reuse
     # when exceeding max pool size.

--- a/tests/performance/conftest.py
+++ b/tests/performance/conftest.py
@@ -4,10 +4,11 @@ from aiocache import Cache
 
 
 @pytest.fixture
-async def redis_cache():
+@pytest.mark.parametrize('max_conns', 1)
+async def redis_cache(redis_client):
     # redis connection pool raises ConnectionError but doesn't wait for conn reuse
-    #  when exceeding max pool size.
-    async with Cache(Cache.REDIS, namespace="test", pool_max_size=1) as cache:
+    # when exceeding max pool size.
+    async with Cache(Cache.REDIS, namespace="test", client=redis_client) as cache:
         yield cache
 
 

--- a/tests/performance/server.py
+++ b/tests/performance/server.py
@@ -2,6 +2,7 @@ import asyncio
 import logging
 import uuid
 
+import redis.asyncio as redis
 from aiohttp import web
 
 from aiocache import Cache
@@ -16,7 +17,17 @@ class CacheManager:
             "redis": Cache.REDIS,
             "memcached": Cache.MEMCACHED,
         }
-        self.cache = Cache(backends[backend])
+        if backend == "redis":
+            cache_kwargs = {'client': redis.Redis(
+                host="127.0.0.1",
+                port=6379,
+                db=0,
+                password=None,
+                decode_responses=False,
+            )}
+        else:
+            cache_kwargs = dict()
+        self.cache = Cache(backends[backend], **cache_kwargs)
 
     async def get(self, key):
         return await self.cache.get(key, timeout=0.1)

--- a/tests/performance/server.py
+++ b/tests/performance/server.py
@@ -18,7 +18,7 @@ class CacheManager:
             "memcached": Cache.MEMCACHED,
         }
         if backend == "redis":
-            cache_kwargs = {'client': redis.Redis(
+            cache_kwargs = {"client": redis.Redis(
                 host="127.0.0.1",
                 port=6379,
                 db=0,

--- a/tests/performance/test_concurrency.py
+++ b/tests/performance/test_concurrency.py
@@ -27,7 +27,7 @@ def test_concurrency_error_rates(server):
     total_requests = 1500
     # On some platforms, it's required to enlarge number of "open file descriptors"
     #  with "ulimit -n number" before doing the benchmark.
-    cmd = ("ab", "-n", str(total_requests), "-c", "500", "http://0.0.0.0:8080/")
+    cmd = ("ab", "-n", str(total_requests), "-c", "500", "http://127.0.0.1:8080/")
     result = subprocess.run(cmd, capture_output=True, check=True, encoding="utf-8")
 
     m = re.search(r"Failed requests:\s+([0-9]+)", result.stdout)

--- a/tests/performance/test_concurrency.py
+++ b/tests/performance/test_concurrency.py
@@ -27,7 +27,7 @@ def test_concurrency_error_rates(server):
     total_requests = 1500
     # On some platforms, it's required to enlarge number of "open file descriptors"
     #  with "ulimit -n number" before doing the benchmark.
-    cmd = ("ab", "-n", str(total_requests), "-c", "500", "http://127.0.0.1:8080/")
+    cmd = ("ab", "-n", str(total_requests), "-c", "500", "http://0.0.0.0:8080/")
     result = subprocess.run(cmd, capture_output=True, check=True, encoding="utf-8")
 
     m = re.search(r"Failed requests:\s+([0-9]+)", result.stdout)

--- a/tests/ut/backends/test_memcached.py
+++ b/tests/ut/backends/test_memcached.py
@@ -38,7 +38,7 @@ class TestMemcachedBackend:
 
     def test_setup_override(self):
         with patch.object(aiomcache, "Client", autospec=True) as aiomcache_client:
-            memcached = MemcachedBackend(endpoint="127.0.0.2", port=2, pool_size=10)
+            memcached = MemcachedBackend(host="127.0.0.2", port=2, pool_size=10)
 
             aiomcache_client.assert_called_with("127.0.0.2", 2, pool_size=10)
 

--- a/tests/ut/backends/test_memcached.py
+++ b/tests/ut/backends/test_memcached.py
@@ -32,7 +32,7 @@ class TestMemcachedBackend:
 
             aiomcache_client.assert_called_with("127.0.0.1", 11211, pool_size=2)
 
-        assert memcached.endpoint == "127.0.0.1"
+        assert memcached.host == "127.0.0.1"
         assert memcached.port == 11211
         assert memcached.pool_size == 2
 
@@ -42,7 +42,7 @@ class TestMemcachedBackend:
 
             aiomcache_client.assert_called_with("127.0.0.2", 2, pool_size=10)
 
-        assert memcached.endpoint == "127.0.0.2"
+        assert memcached.host == "127.0.0.2"
         assert memcached.port == 2
         assert memcached.pool_size == 10
 

--- a/tests/ut/backends/test_redis.py
+++ b/tests/ut/backends/test_redis.py
@@ -30,6 +30,15 @@ def redis(redis_client):
 
 class TestRedisBackend:
 
+    @pytest.mark.parametrize('decode_responses', [True])
+    async def test_redis_backend_requires_client_decode_responses(self, redis_client):
+        with pytest.raises(ValueError) as ve:
+            RedisBackend(client=redis_client)
+
+        assert str(ve.value) == (
+            "redis client must be constructed with decode_responses set to False"
+        )
+
     async def test_get(self, redis):
         redis.client.get.return_value = b"value"
         assert await redis._get(Keys.KEY) == "value"

--- a/tests/ut/backends/test_redis.py
+++ b/tests/ut/backends/test_redis.py
@@ -30,7 +30,7 @@ def redis(redis_client):
 
 class TestRedisBackend:
 
-    @pytest.mark.parametrize('decode_responses', [True])
+    @pytest.mark.parametrize("decode_responses", [True])
     async def test_redis_backend_requires_client_decode_responses(self, redis_client):
         with pytest.raises(ValueError) as ve:
             RedisBackend(client=redis_client)

--- a/tests/ut/backends/test_redis.py
+++ b/tests/ut/backends/test_redis.py
@@ -11,8 +11,8 @@ from ...utils import Keys, ensure_key
 
 
 @pytest.fixture
-def redis():
-    redis = RedisBackend()
+def redis(redis_client):
+    redis = RedisBackend(client=redis_client)
     with patch.object(redis, "client", autospec=True) as m:
         # These methods actually return an awaitable.
         for method in (
@@ -29,64 +29,6 @@ def redis():
 
 
 class TestRedisBackend:
-    default_redis_kwargs = {
-        "host": "127.0.0.1",
-        "port": 6379,
-        "db": 0,
-        "password": None,
-        "socket_connect_timeout": None,
-        "decode_responses": False,
-        "max_connections": None,
-    }
-
-    @patch("redis.asyncio.Redis", name="mock_class", autospec=True)
-    def test_setup(self, mock_class):
-        redis_backend = RedisBackend()
-        kwargs = self.default_redis_kwargs.copy()
-        mock_class.assert_called_with(**kwargs)
-        assert redis_backend.endpoint == "127.0.0.1"
-        assert redis_backend.port == 6379
-        assert redis_backend.db == 0
-        assert redis_backend.password is None
-        assert redis_backend.pool_max_size is None
-
-    @patch("redis.asyncio.Redis", name="mock_class", autospec=True)
-    def test_setup_override(self, mock_class):
-        override = {"db": 2, "password": "pass"}
-        redis_backend = RedisBackend(**override)
-
-        kwargs = self.default_redis_kwargs.copy()
-        kwargs.update(override)
-        mock_class.assert_called_with(**kwargs)
-
-        assert redis_backend.endpoint == "127.0.0.1"
-        assert redis_backend.port == 6379
-        assert redis_backend.db == 2
-        assert redis_backend.password == "pass"
-
-    @patch("redis.asyncio.Redis", name="mock_class", autospec=True)
-    def test_setup_casts(self, mock_class):
-        override = {
-            "db": "2",
-            "port": "6379",
-            "pool_max_size": "10",
-            "create_connection_timeout": "1.5",
-        }
-        redis_backend = RedisBackend(**override)
-
-        kwargs = self.default_redis_kwargs.copy()
-        kwargs.update({
-            "db": 2,
-            "port": 6379,
-            "max_connections": 10,
-            "socket_connect_timeout": 1.5,
-        })
-        mock_class.assert_called_with(**kwargs)
-
-        assert redis_backend.db == 2
-        assert redis_backend.port == 6379
-        assert redis_backend.pool_max_size == 10
-        assert redis_backend.create_connection_timeout == 1.5
 
     async def test_get(self, redis):
         redis.client.get.return_value = b"value"
@@ -224,10 +166,6 @@ class TestRedisBackend:
         await redis._redlock_release(Keys.KEY, "random")
         redis._raw.assert_called_with("eval", redis.RELEASE_SCRIPT, 1, Keys.KEY, "random")
 
-    async def test_close(self, redis):
-        await redis._close()
-        assert redis.client.close.call_count == 1
-
 
 class TestRedisCache:
     @pytest.fixture
@@ -239,17 +177,17 @@ class TestRedisCache:
     def test_name(self):
         assert RedisCache.NAME == "redis"
 
-    def test_inheritance(self):
-        assert isinstance(RedisCache(), BaseCache)
+    def test_inheritance(self, redis_client):
+        assert isinstance(RedisCache(client=redis_client), BaseCache)
 
-    def test_default_serializer(self):
-        assert isinstance(RedisCache().serializer, JsonSerializer)
+    def test_default_serializer(self, redis_client):
+        assert isinstance(RedisCache(client=redis_client).serializer, JsonSerializer)
 
     @pytest.mark.parametrize(
         "path,expected", [("", {}), ("/", {}), ("/1", {"db": "1"}), ("/1/2/3", {"db": "1"})]
     )
-    def test_parse_uri_path(self, path, expected):
-        assert RedisCache().parse_uri_path(path) == expected
+    def test_parse_uri_path(self, path, expected, redis_client):
+        assert RedisCache(client=redis_client).parse_uri_path(path) == expected
 
     @pytest.mark.parametrize(
         "namespace, expected",

--- a/tests/ut/conftest.py
+++ b/tests/ut/conftest.py
@@ -53,10 +53,10 @@ def base_cache():
 
 
 @pytest.fixture
-async def redis_cache():
+async def redis_cache(redis_client):
     from aiocache.backends.redis import RedisCache
 
-    async with RedisCache() as cache:
+    async with RedisCache(client=redis_client) as cache:
         yield cache
 
 

--- a/tests/ut/test_factory.py
+++ b/tests/ut/test_factory.py
@@ -34,15 +34,6 @@ def test_class_from_string():
     assert _class_from_string("aiocache.RedisCache") == RedisCache
 
 
-@pytest.mark.redis
-def test_create_simple_cache():
-    redis = _create_cache(RedisCache, endpoint="127.0.0.10", port=6378)
-
-    assert isinstance(redis, RedisCache)
-    assert redis.endpoint == "127.0.0.10"
-    assert redis.port == 6378
-
-
 def test_create_cache_with_everything():
     cache = _create_cache(
         SimpleMemoryCache,
@@ -97,26 +88,26 @@ class TestCache:
         "url,expected_args",
         [
             ("redis://", {}),
-            ("redis://localhost", {"endpoint": "localhost"}),
-            ("redis://localhost/", {"endpoint": "localhost"}),
-            ("redis://localhost:6379", {"endpoint": "localhost", "port": 6379}),
+            ("redis://localhost", {"host": "localhost"}),
+            ("redis://localhost/", {"host": "localhost"}),
+            ("redis://localhost:6379", {"host": "localhost", "port": 6379}),
             (
                 "redis://localhost/?arg1=arg1&arg2=arg2",
-                {"endpoint": "localhost", "arg1": "arg1", "arg2": "arg2"},
+                {"host": "localhost", "arg1": "arg1", "arg2": "arg2"},
             ),
             (
                 "redis://localhost:6379/?arg1=arg1&arg2=arg2",
-                {"endpoint": "localhost", "port": 6379, "arg1": "arg1", "arg2": "arg2"},
+                {"host": "localhost", "port": 6379, "arg1": "arg1", "arg2": "arg2"},
             ),
             ("redis:///?arg1=arg1", {"arg1": "arg1"}),
             ("redis:///?arg2=arg2", {"arg2": "arg2"}),
             (
                 "redis://:password@localhost:6379",
-                {"endpoint": "localhost", "password": "password", "port": 6379},
+                {"host": "localhost", "password": "password", "port": 6379},
             ),
             (
                 "redis://:password@localhost:6379?password=pass",
-                {"endpoint": "localhost", "password": "password", "port": 6379},
+                {"host": "localhost", "password": "password", "port": 6379},
             ),
         ],
     )
@@ -185,16 +176,16 @@ class TestCacheHandler:
             {
                 "default": {
                     "cache": "aiocache.RedisCache",
-                    "endpoint": "127.0.0.9",
+                    "host": "127.0.0.9",
                     "db": 10,
                     "port": 6378,
                 }
             }
         )
-        cache = caches.create("default", namespace="whatever", endpoint="127.0.0.10", db=10)
+        cache = caches.create("default", namespace="whatever", host="127.0.0.10", db=10)
         assert cache.namespace == "whatever"
-        assert cache.endpoint == "127.0.0.10"
-        assert cache.db == 10
+        assert cache.client.connection_pool.connection_kwargs['host'] == "127.0.0.10"
+        assert cache.client.connection_pool.connection_kwargs['db'] == 10
 
     @pytest.mark.redis
     def test_retrieve_cache(self):
@@ -202,7 +193,7 @@ class TestCacheHandler:
             {
                 "default": {
                     "cache": "aiocache.RedisCache",
-                    "endpoint": "127.0.0.10",
+                    "host": "127.0.0.10",
                     "port": 6378,
                     "ttl": 10,
                     "serializer": {
@@ -219,8 +210,8 @@ class TestCacheHandler:
 
         cache = caches.get("default")
         assert isinstance(cache, RedisCache)
-        assert cache.endpoint == "127.0.0.10"
-        assert cache.port == 6378
+        assert cache.client.connection_pool.connection_kwargs['host'] == "127.0.0.10"
+        assert cache.client.connection_pool.connection_kwargs['port'] == 6378
         assert cache.ttl == 10
         assert isinstance(cache.serializer, PickleSerializer)
         assert cache.serializer.encoding == "encoding"
@@ -232,7 +223,7 @@ class TestCacheHandler:
             {
                 "default": {
                     "cache": "aiocache.RedisCache",
-                    "endpoint": "127.0.0.10",
+                    "host": "127.0.0.10",
                     "port": 6378,
                     "serializer": {
                         "class": "aiocache.serializers.PickleSerializer",
@@ -248,8 +239,8 @@ class TestCacheHandler:
 
         cache = caches.create("default")
         assert isinstance(cache, RedisCache)
-        assert cache.endpoint == "127.0.0.10"
-        assert cache.port == 6378
+        assert cache.client.connection_pool.connection_kwargs['host'] == "127.0.0.10"
+        assert cache.client.connection_pool.connection_kwargs['port'] == 6378
         assert isinstance(cache.serializer, PickleSerializer)
         assert cache.serializer.encoding == "encoding"
         assert len(cache.plugins) == 2
@@ -260,7 +251,7 @@ class TestCacheHandler:
             {
                 "default": {
                     "cache": "aiocache.RedisCache",
-                    "endpoint": "127.0.0.10",
+                    "host": "127.0.0.10",
                     "port": 6378,
                     "serializer": {"class": "aiocache.serializers.PickleSerializer"},
                     "plugins": [
@@ -276,8 +267,8 @@ class TestCacheHandler:
         alt = caches.get("alt")
 
         assert isinstance(default, RedisCache)
-        assert default.endpoint == "127.0.0.10"
-        assert default.port == 6378
+        assert default.client.connection_pool.connection_kwargs['host'] == "127.0.0.10"
+        assert default.client.connection_pool.connection_kwargs['port'] == 6378
         assert isinstance(default.serializer, PickleSerializer)
         assert len(default.plugins) == 2
 
@@ -338,7 +329,7 @@ class TestCacheHandler:
                 {
                     "no_default": {
                         "cache": "aiocache.RedisCache",
-                        "endpoint": "127.0.0.10",
+                        "host": "127.0.0.10",
                         "port": 6378,
                         "serializer": {"class": "aiocache.serializers.PickleSerializer"},
                         "plugins": [

--- a/tests/ut/test_factory.py
+++ b/tests/ut/test_factory.py
@@ -184,8 +184,8 @@ class TestCacheHandler:
         )
         cache = caches.create("default", namespace="whatever", host="127.0.0.10", db=10)
         assert cache.namespace == "whatever"
-        assert cache.client.connection_pool.connection_kwargs['host'] == "127.0.0.10"
-        assert cache.client.connection_pool.connection_kwargs['db'] == 10
+        assert cache.client.connection_pool.connection_kwargs["host"] == "127.0.0.10"
+        assert cache.client.connection_pool.connection_kwargs["db"] == 10
 
     @pytest.mark.redis
     def test_retrieve_cache(self):
@@ -210,8 +210,8 @@ class TestCacheHandler:
 
         cache = caches.get("default")
         assert isinstance(cache, RedisCache)
-        assert cache.client.connection_pool.connection_kwargs['host'] == "127.0.0.10"
-        assert cache.client.connection_pool.connection_kwargs['port'] == 6378
+        assert cache.client.connection_pool.connection_kwargs["host"] == "127.0.0.10"
+        assert cache.client.connection_pool.connection_kwargs["port"] == 6378
         assert cache.ttl == 10
         assert isinstance(cache.serializer, PickleSerializer)
         assert cache.serializer.encoding == "encoding"
@@ -239,8 +239,8 @@ class TestCacheHandler:
 
         cache = caches.create("default")
         assert isinstance(cache, RedisCache)
-        assert cache.client.connection_pool.connection_kwargs['host'] == "127.0.0.10"
-        assert cache.client.connection_pool.connection_kwargs['port'] == 6378
+        assert cache.client.connection_pool.connection_kwargs["host"] == "127.0.0.10"
+        assert cache.client.connection_pool.connection_kwargs["port"] == 6378
         assert isinstance(cache.serializer, PickleSerializer)
         assert cache.serializer.encoding == "encoding"
         assert len(cache.plugins) == 2
@@ -267,8 +267,8 @@ class TestCacheHandler:
         alt = caches.get("alt")
 
         assert isinstance(default, RedisCache)
-        assert default.client.connection_pool.connection_kwargs['host'] == "127.0.0.10"
-        assert default.client.connection_pool.connection_kwargs['port'] == 6378
+        assert default.client.connection_pool.connection_kwargs["host"] == "127.0.0.10"
+        assert default.client.connection_pool.connection_kwargs["port"] == 6378
         assert isinstance(default.serializer, PickleSerializer)
         assert len(default.plugins) == 2
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?
These changes implement the feedback from this PR:
https://github.com/aio-libs/aiocache/pull/691#issuecomment-1587624406
Fixes #550 

This PR removes the construction of the redis.Redis object from the RedisBackend class and makes it a dependency. This allows users of the library to construct their Redis instances which might have to have a custom SSL cert, or be a more complex use case.  This allows apps using this package to only have one redis instance to manage if they want to use redis for other things.

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

This PR also does a few other things (unfortunately)
0. It changes the constructor of the RedisBackend to take in a client instead of client args. This means that the `RedisBackend` class's public members like `port` will be moved to deeper in the code. 
1. it renames `endpoint` to `host`. This naming is consistent with [redis](https://github.com/redis/redis-py/blob/28cc65c18cc4fb37ef14497c963eb181dba8d25d/redis/asyncio/client.py#L173) and your [aiomcache library](https://github.com/aio-libs/aiomcache/blob/083ea0627ef17245aa6ff165a224b5a923f631e1/aiomcache/client.py#L61)
2. It renames the redis URLstrings `pool_max_size` --> `pool_max_size` and `create_connection_timeout` --> `create_connection_timeout` to be consistent with the naming in redis-py. 
3. It removes the `pool_min_size` from the RedisBackend constructor (I assume I may as well remove it) 

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #691

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
