### PR TITLE
Raise correct error message when create cache proxy with absent cache type

### DIFF
--- a/aiocache/factory.py
+++ b/aiocache/factory.py
@@ -72,7 +72,7 @@ class Cache:
     MEMCACHED = AIOCACHE_CACHES.get("memcached")
 
     def __new__(cls, cache_class=MEMORY, **kwargs):
-        if not issubclass(cache_class, BaseCache):
+        if not (cache_class and issubclass(cache_class, BaseCache)):
             raise InvalidCacheType(
                 "Invalid cache type, you can only use {}".format(list(AIOCACHE_CACHES.keys()))
             )

--- a/tests/ut/test_factory.py
+++ b/tests/ut/test_factory.py
@@ -65,9 +65,10 @@ class TestCache:
     def test_new_defaults_to_memory(self):
         assert isinstance(Cache(), Cache.MEMORY)
 
-    def test_new_invalid_cache_raises(self):
+    @pytest.mark.parametrize("cache_type", (None, object))
+    def test_new_invalid_cache_raises(self, cache_type):
         with pytest.raises(InvalidCacheType) as e:
-            Cache(object)
+            Cache(cache_type)
         assert str(e.value) == "Invalid cache type, you can only use {}".format(
             list(AIOCACHE_CACHES.keys())
         )


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

I got this error message when tried to use aiocache with redis.
```
assert issubclass(cache_class, BaseCache)
TypeError: issubclass() arg 1 must be a class
```

Basically, I wasn't sure which dependency is missed, because I assumed `pip install aiocache` should install all required. Also this command from readme doesn't work for me.

```
>> pip install aiocache[redis]
zsh: no matches found: aiocache[redis]
``` 

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- Remember to prefix with 'Fixes' if it should close the issue (e.g. 'Fixes #123'). -->
[Fixes #539](https://github.com/aio-libs/aiocache/issues/539) 

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
