### PR TITLE
fix: prevent memory leak in _redlock_release of SimpleMemoryBackend

### DIFF
--- a/aiocache/backends/memory.py
+++ b/aiocache/backends/memory.py
@@ -94,8 +94,7 @@ class SimpleMemoryBackend(BaseCache[str]):
 
     async def _redlock_release(self, key, value):
         if self._cache.get(key) == value:
-            self._cache.pop(key)
-            return 1
+            return self.__delete(key)
         return 0
 
     def __delete(self, key):

--- a/tests/ut/backends/test_memory.py
+++ b/tests/ut/backends/test_memory.py
@@ -173,9 +173,13 @@ class TestSimpleMemoryBackend:
 
     async def test_redlock_release(self, memory):
         memory._cache.get.return_value = "lock"
+        fake = create_autospec(asyncio.TimerHandle, instance=True)
+        memory._handlers[Keys.KEY] = fake
         assert await memory._redlock_release(Keys.KEY, "lock") == 1
         memory._cache.get.assert_called_with(Keys.KEY)
-        memory._cache.pop.assert_called_with(Keys.KEY)
+        memory._cache.pop.assert_called_with(Keys.KEY, None)
+        assert fake.cancel.call_count == 1
+        assert Keys.KEY not in memory._handlers
 
     async def test_redlock_release_nokey(self, memory):
         memory._cache.get.return_value = None


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
The changes refactor the `_redlock_release` method in the `SimpleMemoryBackend` class. Instead of directly removing items from the `_cache` dictionary using the `pop` method, the method now invokes the `__delete` method. This ensures that when an item is released from the cache, associated timer handles in the `_handlers` dictionary are also properly cancelled, thereby preventing potential memory leaks.

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->
There are no direct changes in behavior for the end user. This update enhances the internal memory management of the cache system, contributing to improved stability and efficiency without altering the functional interface.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- Remember to prefix with 'Fixes' if it should close the issue (e.g. 'Fixes #123'). -->

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
