### PR TITLE
Fix typo in comment in serializers.py

### DIFF
--- a/aiocache/serializers/serializers.py
+++ b/aiocache/serializers/serializers.py
@@ -77,7 +77,7 @@ class StringSerializer(BaseSerializer):
     The transformation is done by just casting to str in the ``dumps`` method.
 
     If you want to keep python types, use ``PickleSerializer``. ``JsonSerializer``
-    may also be useful to keep type of symple python types.
+    may also be useful to keep type of simple python types.
     """
 
     def dumps(self, value):


### PR DESCRIPTION
Fix typo in StringSerializer's comment header, in serializers.py. "symple" is changed to "simple".

<!-- Thank you for your contribution! -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

In ``aiocache/serializers/serializers.py``, there's a typo in the comment header of the StringSerializer class. The typo "symple" is changed to "simple" in this commit. 

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->
No other changes than the comment header of StringSerializer visually shown in IDEs.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- Remember to prefix with 'Fixes' if it should close the issue (e.g. 'Fixes #123'). -->
No related issues.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
