### PR TITLE
Add minimal typing for decorators

### DIFF
--- a/aiocache/decorators.py
+++ b/aiocache/decorators.py
@@ -2,12 +2,15 @@ import asyncio
 import functools
 import inspect
 import logging
+from typing import TypeVar
 
 from aiocache.base import SENTINEL
 from aiocache.factory import Cache, caches
 from aiocache.lock import RedLock
 
 logger = logging.getLogger(__name__)
+
+Function = TypeVar("Function")
 
 
 class cached:
@@ -83,7 +86,7 @@ class cached:
         self._plugins = plugins
         self._kwargs = kwargs
 
-    def __call__(self, f):
+    def __call__(self, f: Function) -> Function:
         if self.alias:
             self.cache = caches.get(self.alias)
             for arg in ("serializer", "namespace", "plugins"):
@@ -326,7 +329,7 @@ class multi_cached:
         self._plugins = plugins
         self._kwargs = kwargs
 
-    def __call__(self, f):
+    def __call__(self, f: Function) -> Function:
         if self.alias:
             self.cache = caches.get(self.alias)
             for arg in ("serializer", "namespace", "plugins"):


### PR DESCRIPTION
## What do these changes do?

The task of adding full typing to the library is quite a long one. We can wait long enough for contributors to have time.

Since we are already using the library today, I suggest covering the smallest, but most frequently used part of it in the simplest way.

Even if it is more correct to describe ParamSpec, etc. - let's do it in this minimal version. And as soon as the contributors have the strength and time, we will redo it in the target form.

## Are there changes in behavior for the user?

Displaying original type hints of decorated function

### Before

<img width="302" alt="Screenshot 2024-09-03 at 00 03 47" src="https://github.com/user-attachments/assets/290302ec-2e20-4315-80e1-bf6b793131a5">


### After

<img width="304" alt="Screenshot 2024-09-03 at 00 04 26" src="https://github.com/user-attachments/assets/510b937e-c93a-46af-9e8a-55eb5b7b0cf4">


## Related issue number

Related to #512 (as a temporary solution)

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
