### PR TITLE
Add license to project metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(
     author="Manuel Miranda",
     url="https://github.com/aio-libs/aiocache",
     author_email="manu.mirandad@gmail.com",
+    license="BSD-3-Clause",
     description="multi backend asyncio cache",
     long_description=readme,
     classifiers=[


### PR DESCRIPTION
## What do these changes do?
Add the SPDX identifier for the BSD license to the project metadata.
https://github.com/aio-libs/aiocache/blob/master/LICENSE