### PR TITLE
feat: add invalidate_cache for @cached decorator

### DIFF
--- a/aiocache/decorators.py
+++ b/aiocache/decorators.py
@@ -15,6 +15,10 @@ class cached:
     Caches the functions return value into a key generated with module_name, function_name
     and args. The cache is available in the function object as ``<function_name>.cache``.
 
+    To invalidate the cache, you can use the ``invalidate_cache`` method of the function object by
+    passing the args that were used to generate the cache key as
+    ``<function_name>.invalidate_cache(*args, **kwargs)``.
+
     In some cases you will need to send more args to configure the cache object.
     An example would be endpoint and port for the Redis cache. You can send those args as
     kwargs and they will be propagated accordingly.
@@ -77,6 +81,7 @@ class cached:
         self.alias = alias
         self.cache = None
 
+        self._func = None
         self._cache = cache
         self._serializer = serializer
         self._namespace = namespace
@@ -84,10 +89,12 @@ class cached:
         self._kwargs = kwargs
 
     def __call__(self, f):
+        self._func = f
+
         if self.alias:
             self.cache = caches.get(self.alias)
             for arg in ("serializer", "namespace", "plugins"):
-                if getattr(self, f'_{arg}', None) is not None:
+                if getattr(self, f"_{arg}", None) is not None:
                     logger.warning(f"Using cache alias; ignoring {arg!r} argument.")
         else:
             self.cache = _get_cache(
@@ -103,6 +110,7 @@ class cached:
             return await self.decorator(f, *args, **kwargs)
 
         wrapper.cache = self.cache
+        wrapper.invalidate_cache = self.invalidate_cache
         return wrapper
 
     async def decorator(
@@ -156,6 +164,10 @@ class cached:
             await self.cache.set(key, value, ttl=self.ttl)
         except Exception:
             logger.exception("Couldn't set %s in key %s, unexpected error", value, key)
+
+    async def invalidate_cache(self, *args, **kwargs):
+        key = self.get_cache_key(self._func, args, kwargs)
+        return await self.cache.delete(key)
 
 
 class cached_stampede(cached):
@@ -330,7 +342,7 @@ class multi_cached:
         if self.alias:
             self.cache = caches.get(self.alias)
             for arg in ("serializer", "namespace", "plugins"):
-                if getattr(self, f'_{arg}', None) is not None:
+                if getattr(self, f"_{arg}", None) is not None:
                     logger.warning(f"Using cache alias; ignoring {arg!r} argument.")
         else:
             self.cache = _get_cache(

--- a/aiocache/decorators.py
+++ b/aiocache/decorators.py
@@ -17,7 +17,7 @@ class cached:
 
     To invalidate the cache, you can use the ``invalidate_cache`` method of the function object by
     passing the args that were used to generate the cache key as
-    ``<function_name>.invalidate_cache(*args, **kwargs)``.
+    ``await <function_name>.invalidate_cache(*args, **kwargs)``. It is an async method.
 
     In some cases you will need to send more args to configure the cache object.
     An example would be endpoint and port for the Redis cache. You can send those args as

--- a/tests/ut/test_decorators.py
+++ b/tests/ut/test_decorators.py
@@ -233,6 +233,54 @@ class TestCached:
 
         assert foo.cache != bar.cache
 
+    async def test_invalidate_cache_exists(self):
+        @cached()
+        async def foo():
+            """Dummy function."""
+
+        assert callable(foo.invalidate_cache)
+
+    async def test_invalidate_cache(self):
+        times_called = 0
+
+        @cached()
+        async def foo():
+            nonlocal times_called
+            times_called += 1
+
+        await foo()
+        assert times_called == 1
+
+        await foo.invalidate_cache()
+        await foo()
+        assert times_called == 2
+
+    async def test_invalidate_cache_multiple_functions(self):
+        foo_times_called = 0
+
+        @cached()
+        async def foo():
+            nonlocal foo_times_called
+            foo_times_called += 1
+
+        bar_times_called = 0
+
+        @cached()
+        async def bar():
+            nonlocal bar_times_called
+            bar_times_called += 1
+
+        await foo()
+        assert foo_times_called == 1
+
+        await bar()
+        assert bar_times_called == 1
+
+        await foo.invalidate_cache()
+        await foo()
+        assert foo_times_called == 2
+        assert bar_times_called == 1
+
 
 class TestCachedStampede:
     @pytest.fixture

--- a/tests/ut/test_decorators.py
+++ b/tests/ut/test_decorators.py
@@ -262,6 +262,35 @@ class TestCached:
         await foo("hello")  # doesn't increment cache_misses since it's cached
         assert cache_misses == 2
 
+    async def test_invalidate_cache_diff_args(self):
+        """
+        Tests that the invalidate_cache invalidates the cache for the correct arguments.
+        """
+
+        cache_misses = 0
+
+        @cached(ttl=60 * 60)
+        async def foo(return_value: str):
+            nonlocal cache_misses
+            cache_misses += 1
+            return return_value
+
+        await foo("hello")  # increments cache_misses since "hello" is not cached
+        assert cache_misses == 1
+
+        await foo("world")  # increments cache_misses since "world" is not cached
+        assert cache_misses == 2
+
+        await foo.invalidate_cache("world")
+        await foo("hello")  # doesn't increment cache_misses since "hello" is still cached
+        await foo("hello")
+        await foo("hello")
+        await foo("hello")
+        assert cache_misses == 2
+
+        await foo("world")
+        assert cache_misses == 3
+
 
 class TestCachedStampede:
     @pytest.fixture


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

This PR adds an `invalidate_cache` function to the `aiocache` library, allowing users to explicitly invalidate the cache of a function decorated with `@cache`. Users can call the method directly on the cached function object with the arguments that were used to generate the cache key. Usage:
```python
await <function_name>.invalidate_cache(*args, **kwargs)
```

## Are there changes in behavior for the user?

Yes, this new functionality provides users with a convenient way to manually invalidate the cache for specific arguments of a cached function, enhancing flexibility and control over cache management.

## Related issue number

N/A

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
