### PR TITLE
Wrap decorators and add cache control API (#625)

### DIFF
--- a/docs/decorators.rst
+++ b/docs/decorators.rst
@@ -17,6 +17,22 @@ cached
   :language: python
   :linenos:
 
+The ``@cached`` decorator returns a wrapper object that exposes cache control methods, such as ``.refresh()`` and ``.invalidate()``. Use ``.refresh()`` to force a cache refresh for the given arguments, bypassing the cache.
+
+**Example:**
+
+.. code-block:: python
+
+   @cached()
+   async def compute(x):
+       return x * 2
+
+   await compute(1)         # Uses cache if available
+   await compute.refresh(1) # Forces refresh, updates cache
+
+   await compute.invalidate()    # Invalidate all cache keys
+   await compute.invalidate(key) # Invalidate a specific cache key
+
 ..  _multi_cached:
 
 multi_cached


### PR DESCRIPTION
## What do these changes do?

Refactored `@cached` and `@multi_cached` to return a wrapper object providing cache control:
- **refresh**: forces a cache update for the given key.
- **invalidate**: clears the cache for the given key, or clears all if no key is given.

## Are there changes in behavior for the user?

Users can now call `refresh()` and `invalidate()` on decorated functions or methods to control the cache directly.

No breaking changes to existing cache usage patterns.

## Related issue number

Fixes #625
Replaces #927

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
