### PR TITLE
feat(typing)!: make cache generic over value (#608)

### DIFF
--- a/aiocache/__init__.py
+++ b/aiocache/__init__.py
@@ -8,7 +8,7 @@ __version__ = "1.0.0a0"
 
 logger = logging.getLogger(__name__)
 
-_AIOCACHE_CACHES: list[Type[BaseCache[Any]]] = [SimpleMemoryCache]
+_AIOCACHE_CACHES: list[Type[BaseCache[Any, Any]]] = [SimpleMemoryCache]
 
 try:
     import redis

--- a/aiocache/backends/memcached.py
+++ b/aiocache/backends/memcached.py
@@ -1,5 +1,5 @@
 import asyncio
-from typing import Optional
+from typing import Any, Optional
 
 import aiomcache
 
@@ -7,7 +7,7 @@ from aiocache.base import BaseCache
 from aiocache.serializers import JsonSerializer
 
 
-class MemcachedBackend(BaseCache[bytes]):
+class MemcachedBackend(BaseCache[bytes, Any]):
     def __init__(self, host="127.0.0.1", port=11211, pool_size=2, **kwargs):
         super().__init__(**kwargs)
         self.host = host

--- a/aiocache/backends/memory.py
+++ b/aiocache/backends/memory.py
@@ -1,11 +1,16 @@
 import asyncio
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, TypeVar
 
 from aiocache.base import BaseCache
 from aiocache.serializers import NullSerializer
 
+CacheKeyType = TypeVar('CacheKeyType')
+CacheValueType = TypeVar('CacheValueType')
 
-class SimpleMemoryBackend(BaseCache[str]):
+
+class SimpleMemoryBackend(
+    BaseCache[CacheKeyType, CacheValueType],
+):
     """
     Wrapper around dict operations to use it as a cache backend
     """
@@ -110,7 +115,7 @@ class SimpleMemoryBackend(BaseCache[str]):
         return self._str_build_key(key, namespace)
 
 
-class SimpleMemoryCache(SimpleMemoryBackend):
+class SimpleMemoryCache(SimpleMemoryBackend[str, Any]):
     """
     Memory cache implementation with the following components as defaults:
         - serializer: :class:`aiocache.serializers.NullSerializer`

--- a/aiocache/backends/redis.py
+++ b/aiocache/backends/redis.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from aiocache.serializers import BaseSerializer
 
 
-class RedisBackend(BaseCache[str]):
+class RedisBackend(BaseCache[str, Any]):
     RELEASE_SCRIPT = (
         "if redis.call('get',KEYS[1]) == ARGV[1] then"
         " return redis.call('del',KEYS[1])"

--- a/aiocache/lock.py
+++ b/aiocache/lock.py
@@ -62,7 +62,7 @@ class RedLock(Generic[CacheKeyType]):
 
     _EVENTS: Dict[str, asyncio.Event] = {}
 
-    def __init__(self, client: BaseCache[CacheKeyType], key: str, lease: Union[int, float]):
+    def __init__(self, client: BaseCache[CacheKeyType, Any], key: str, lease: Union[int, float]):
         self.client = client
         self.key = self.client.build_key(key + "-lock")
         self.lease = lease
@@ -133,7 +133,7 @@ class OptimisticLock(Generic[CacheKeyType]):
     If the lock is created with an unexisting key, there will never be conflicts.
     """
 
-    def __init__(self, client: BaseCache[CacheKeyType], key: str):
+    def __init__(self, client: BaseCache[CacheKeyType, Any], key: str):
         self.client = client
         self.key = key
         self.ns_key = self.client.build_key(key)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Optional, Union
+from typing import Any, Optional, Union
 
 from aiocache.base import BaseCache
 
@@ -19,7 +19,7 @@ def ensure_key(key: Union[str, Enum]) -> str:
         return key
 
 
-class AbstractBaseCache(BaseCache[str]):
+class AbstractBaseCache(BaseCache[str, Any]):
     """BaseCache that can be mocked for NotImplementedError tests"""
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)


### PR DESCRIPTION
## What do these changes do?

- Make BaseCache generic over both key and value types for improved type safety.
- Update all cache backends and usages to use BaseCache[KeyType, ValueType].
- Improve type annotations for cache methods.

## Are there changes in behavior for the user?

BREAKING CHANGE: BaseCache and all backends now require two type parameters (key, value). Existing code using a single type parameter must be updated.

Before, users could write:

    cache: BaseCache[str] = ...

Users must now write:

    cache: BaseCache[str, Any] = ...
    # or for stricter typing:
    cache: BaseCache[str, int] = ...

## Related issue number

Fixes: #608

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
