### PR TITLE
Merge Memcached Backend and Cache classes

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -7,7 +7,7 @@ select = A,B,C,D,E,F,G,H,I,J,K,L,M,N,O,P,Q,R,S,T,U,V,W,X,Y,Z,B901,B902,B903,B950
 # E501,W505: Superseeded by B950 (from Bugbear)
 # E722: Superseeded by B001 (from Bugbear)
 # W503: Mutually exclusive with W504.
-ignore = E226,E501,E722,W503,W505
+ignore = E226,E501,E704,E722,W503,W505
 per-file-ignores =
     # S*: Bandit security checks not useful in tests.
     tests/*:S

--- a/aiocache/backends/memcached.py
+++ b/aiocache/backends/memcached.py
@@ -165,8 +165,8 @@ class MemcachedCache(BaseCache[bytes]):
     async def _expire(self, key: bytes, ttl: int, _conn: _Conn | None = None) -> bool:
         return await self.client.touch(key, ttl)
 
-    async def _delete(self, key: bytes, _conn: _Conn | None = None) -> bool:
-        return True if await self.client.delete(key) else False
+    async def _delete(self, key: bytes, _conn: _Conn | None = None) -> int:
+        return 1 if await self.client.delete(key) else 0
 
     async def _clear(
         self, namespace: str | None = None, _conn: _Conn | None = None
@@ -191,7 +191,7 @@ class MemcachedCache(BaseCache[bytes]):
                 return value.decode(encoding)
         return value
 
-    async def _redlock_release(self, key: bytes, _: Any) -> bool:
+    async def _redlock_release(self, key: bytes, _: Any) -> int:
         # Not ideal, should check the value coincides first but this would introduce
         # race conditions
         return await self._delete(key)

--- a/aiocache/backends/memcached.py
+++ b/aiocache/backends/memcached.py
@@ -1,130 +1,14 @@
 import asyncio
-from typing import Optional
+from collections.abc import Mapping
+from typing import Any, Iterable, MutableSequence, Unpack, overload
 
 import aiomcache
 
-from aiocache.base import BaseCache
+from aiocache.base import BaseCache, BaseCacheKwargs, _Conn
 from aiocache.serializers import JsonSerializer
 
 
-class MemcachedBackend(BaseCache[bytes]):
-    def __init__(self, host="127.0.0.1", port=11211, pool_size=2, **kwargs):
-        super().__init__(**kwargs)
-        self.host = host
-        self.port = port
-        self.pool_size = int(pool_size)
-        self.client = aiomcache.Client(
-            self.host, self.port, pool_size=self.pool_size
-        )
-
-    async def _get(self, key, encoding="utf-8", _conn=None):
-        value = await self.client.get(key)
-        if encoding is None or value is None:
-            return value
-        return value.decode(encoding)
-
-    async def _gets(self, key, encoding="utf-8", _conn=None):
-        key = key.encode() if isinstance(key, str) else key
-        _, token = await self.client.gets(key)
-        return token
-
-    async def _multi_get(self, keys, encoding="utf-8", _conn=None):
-        values = []
-        for value in await self.client.multi_get(*keys):
-            if encoding is None or value is None:
-                values.append(value)
-            else:
-                values.append(value.decode(encoding))
-        return values
-
-    async def _set(self, key, value, ttl=0, _cas_token=None, _conn=None):
-        value = value.encode() if isinstance(value, str) else value
-        if _cas_token is not None:
-            return await self._cas(key, value, _cas_token, ttl=ttl, _conn=_conn)
-        try:
-            return await self.client.set(key, value, exptime=ttl or 0)
-        except aiomcache.exceptions.ValidationException as e:
-            raise TypeError("aiomcache error: {}".format(str(e)))
-
-    async def _cas(self, key, value, token, ttl=None, _conn=None):
-        return await self.client.cas(key, value, token, exptime=ttl or 0)
-
-    async def _multi_set(self, pairs, ttl=0, _conn=None):
-        tasks = []
-        for key, value in pairs:
-            value = str.encode(value) if isinstance(value, str) else value
-            tasks.append(self.client.set(key, value, exptime=ttl or 0))
-
-        try:
-            await asyncio.gather(*tasks)
-        except aiomcache.exceptions.ValidationException as e:
-            raise TypeError("aiomcache error: {}".format(str(e)))
-
-        return True
-
-    async def _add(self, key, value, ttl=0, _conn=None):
-        value = str.encode(value) if isinstance(value, str) else value
-        try:
-            ret = await self.client.add(key, value, exptime=ttl or 0)
-        except aiomcache.exceptions.ValidationException as e:
-            raise TypeError("aiomcache error: {}".format(str(e)))
-        if not ret:
-            raise ValueError("Key {} already exists, use .set to update the value".format(key))
-
-        return True
-
-    async def _exists(self, key, _conn=None):
-        return await self.client.append(key, b"")
-
-    async def _increment(self, key, delta, _conn=None):
-        incremented = None
-        try:
-            if delta > 0:
-                incremented = await self.client.incr(key, delta)
-            else:
-                incremented = await self.client.decr(key, abs(delta))
-        except aiomcache.exceptions.ClientException as e:
-            if "NOT_FOUND" in str(e):
-                await self._set(key, str(delta).encode())
-            else:
-                raise TypeError("aiomcache error: {}".format(str(e)))
-
-        return incremented or delta
-
-    async def _expire(self, key, ttl, _conn=None):
-        return await self.client.touch(key, ttl)
-
-    async def _delete(self, key, _conn=None):
-        return 1 if await self.client.delete(key) else 0
-
-    async def _clear(self, namespace=None, _conn=None):
-        if namespace:
-            raise ValueError("MemcachedBackend doesnt support flushing by namespace")
-        else:
-            await self.client.flush_all()
-        return True
-
-    async def _raw(self, command, *args, encoding="utf-8", _conn=None, **kwargs):
-        value = await getattr(self.client, command)(*args, **kwargs)
-        if command in {"get", "multi_get"}:
-            if encoding is not None and value is not None:
-                return value.decode(encoding)
-        return value
-
-    async def _redlock_release(self, key, _):
-        # Not ideal, should check the value coincides first but this would introduce
-        # race conditions
-        return await self._delete(key)
-
-    async def _close(self, *args, _conn=None, **kwargs):
-        await self.client.close()
-
-    def build_key(self, key: str, namespace: Optional[str] = None) -> bytes:
-        ns_key = self._str_build_key(key, namespace).replace(" ", "_")
-        return str.encode(ns_key)
-
-
-class MemcachedCache(MemcachedBackend):
+class MemcachedCache(BaseCache[bytes]):
     """
     Memcached cache implementation with the following components as defaults:
         - serializer: :class:`aiocache.serializers.JsonSerializer`
@@ -145,12 +29,185 @@ class MemcachedCache(MemcachedBackend):
 
     NAME = "memcached"
 
-    def __init__(self, serializer=None, **kwargs):
-        super().__init__(serializer=serializer or JsonSerializer(), **kwargs)
+    def __init__(
+        self,
+        host: str = "127.0.0.1",
+        port: int = 11211,
+        pool_size: int = 2,
+        **kwargs: Unpack[BaseCacheKwargs],
+    ) -> None:
+        if 'serializer' not in kwargs:
+            kwargs['serializer'] = JsonSerializer()
+        super().__init__(**kwargs)
+        self.host = host
+        self.port = port
+        self.pool_size = int(pool_size)
+        self.client = aiomcache.Client(self.host, self.port, pool_size=self.pool_size)
+
+    async def _get(
+        self, key: bytes, encoding: str = "utf-8", _conn: _Conn | None = None
+    ) -> str | bytes | None:
+        value = await self.client.get(key)
+        if encoding is None or value is None:
+            return value
+        return value.decode(encoding)
+
+    async def _gets(
+        self, key: str | bytes, encoding: str = "utf-8", _conn: _Conn | None = None
+    ) -> int | None:
+        key = key.encode() if isinstance(key, str) else key
+        _, token = await self.client.gets(key)
+        return token
+
+    @overload
+    async def _multi_get(
+        self, keys: MutableSequence[bytes], encoding: str, _conn: _Conn | None = None
+    ) -> list[str]: ...
+
+    @overload
+    async def _multi_get(
+        self, keys: MutableSequence[bytes], encoding: None, _conn: _Conn | None = None
+    ) -> list[bytes | None]: ...
+
+    async def _multi_get(
+        self,
+        keys: MutableSequence[bytes],
+        encoding: str | None = "utf-8",
+        _conn: _Conn | None = None,
+    ) -> list[bytes | None] | list[str]:
+        values = []
+        for value in await self.client.multi_get(*keys):
+            if encoding is None or value is None:
+                values.append(value)
+            else:
+                values.append(value.decode(encoding))  # type: ignore[arg-type]
+        return values
+
+    async def _set(
+        self,
+        key: bytes,
+        value: str | bytes,
+        ttl: int = 0,
+        _cas_token: Any | None = None,
+        _conn: _Conn | None = None,
+    ) -> bool:
+        value = value.encode() if isinstance(value, str) else value
+        if _cas_token is not None:
+            return await self._cas(key, value, _cas_token, ttl=ttl, _conn=_conn)
+        try:
+            return await self.client.set(key, value, exptime=ttl or 0)
+        except aiomcache.exceptions.ValidationException as e:
+            raise TypeError("aiomcache error: {}".format(str(e)))
+
+    async def _cas(
+        self,
+        key: bytes,
+        value: bytes,
+        token: int,
+        ttl: int | None = None,
+        _conn: _Conn | None = None,
+    ) -> bool:
+        return await self.client.cas(key, value, token, exptime=ttl or 0)
+
+    async def _multi_set(
+        self,
+        pairs: Iterable[tuple[bytes, str | bytes]],
+        ttl: int = 0,
+        _conn: _Conn | None = None,
+    ) -> bool:
+        tasks = []
+        for key, value in pairs:
+            value = str.encode(value) if isinstance(value, str) else value
+            tasks.append(self.client.set(key, value, exptime=ttl or 0))
+
+        try:
+            await asyncio.gather(*tasks)
+        except aiomcache.exceptions.ValidationException as e:
+            raise TypeError("aiomcache error: {}".format(str(e)))
+
+        return True
+
+    async def _add(
+        self, key: bytes, value: str | bytes, ttl: int = 0, _conn: _Conn | None = None
+    ) -> bool:
+        value = str.encode(value) if isinstance(value, str) else value
+        try:
+            ret = await self.client.add(key, value, exptime=ttl or 0)
+        except aiomcache.exceptions.ValidationException as e:
+            raise TypeError("aiomcache error: {}".format(str(e)))
+        if not ret:
+            raise ValueError(
+                "Key {!r} already exists, use .set to update the value".format(key)
+            )
+
+        return True
+
+    async def _exists(self, key: bytes, _conn: _Conn | None = None) -> bool:
+        return await self.client.append(key, b"")
+
+    async def _increment(
+        self, key: bytes, delta: int, _conn: _Conn | None = None
+    ) -> int:
+        incremented: int | None = None
+        try:
+            if delta > 0:
+                incremented = await self.client.incr(key, delta)
+            else:
+                incremented = await self.client.decr(key, abs(delta))
+        except aiomcache.exceptions.ClientException as e:
+            if "NOT_FOUND" in str(e):
+                await self._set(key, str(delta).encode())
+            else:
+                raise TypeError("aiomcache error: {}".format(str(e)))
+
+        return incremented or delta
+
+    async def _expire(self, key: bytes, ttl: int, _conn: _Conn | None = None) -> bool:
+        return await self.client.touch(key, ttl)
+
+    async def _delete(self, key: bytes, _conn: _Conn | None = None) -> bool:
+        return True if await self.client.delete(key) else False
+
+    async def _clear(
+        self, namespace: str | None = None, _conn: _Conn | None = None
+    ) -> bool:
+        if namespace:
+            raise ValueError("MemcachedBackend doesnt support flushing by namespace")
+        else:
+            await self.client.flush_all()
+        return True
+
+    async def _raw(
+        self,
+        command: str,
+        *args: tuple[Any, ...],
+        encoding: str = "utf-8",
+        _conn: _Conn | None = None,
+        **kwargs: Mapping[str, Any],
+    ) -> str | bytes | None:
+        value: bytes = await getattr(self.client, command)(*args, **kwargs)
+        if command in {"get", "multi_get"}:
+            if encoding is not None and value is not None:
+                return value.decode(encoding)
+        return value
+
+    async def _redlock_release(self, key: bytes, _: Any) -> bool:
+        # Not ideal, should check the value coincides first but this would introduce
+        # race conditions
+        return await self._delete(key)
+
+    async def _close(
+        self, *args: Any, _conn: _Conn | None = None, **kwargs: Any
+    ) -> None:
+        await self.client.close()
+
+    def build_key(self, key: str, namespace: str | None = None) -> bytes:
+        ns_key = self._str_build_key(key, namespace).replace(" ", "_")
+        return str.encode(ns_key)
 
     @classmethod
-    def parse_uri_path(cls, path):
+    def parse_uri_path(cls, path: str) -> dict[Any, Any]:
         return {}
 
-    def __repr__(self):  # pragma: no cover
+    def __repr__(self) -> str:  # pragma: no cover
         return "MemcachedCache ({}:{})".format(self.host, self.port)

--- a/aiocache/backends/memcached.py
+++ b/aiocache/backends/memcached.py
@@ -172,7 +172,7 @@ class MemcachedCache(BaseCache[bytes]):
         self, namespace: str | None = None, _conn: _Conn | None = None
     ) -> bool:
         if namespace:
-            raise ValueError("MemcachedBackend doesnt support flushing by namespace")
+            raise ValueError("MemcachedCache doesnt support flushing by namespace")
         else:
             await self.client.flush_all()
         return True

--- a/aiocache/base.py
+++ b/aiocache/base.py
@@ -6,7 +6,17 @@ import time
 from abc import ABC, abstractmethod
 from enum import Enum
 from types import TracebackType
-from typing import Callable, Generic, List, Optional, Set, TYPE_CHECKING, Type, TypeVar
+from typing import (
+    Callable,
+    Generic,
+    List,
+    Optional,
+    Set,
+    TYPE_CHECKING,
+    Type,
+    TypeVar,
+    TypedDict,
+)
 
 from aiocache.serializers import StringSerializer
 
@@ -91,6 +101,15 @@ class API:
             return ret
 
         return _plugins
+
+
+class BaseCacheKwargs(TypedDict, total=False):
+    serializer: Optional["BaseSerializer"]
+    plugins: Optional[list["BasePlugin"]]
+    namespace: str
+    key_builder: Callable[[str, str], str]
+    timeout: Optional[float]
+    ttl: Optional[float]
 
 
 class BaseCache(Generic[CacheKeyType], ABC):


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

- Merge `MemcachedBackend` and `MemcachedCache` classes.
- Add type hints for the new class.
- Merge `MemcachedBackend` and `MemcachedCache` tests.

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

Users extending from `MemcachedBackend` will have replace it MemcachedCache

```diff
- from aiocache import MemcachedBackend
+ from aiocache import MemcachedCache
```

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

#684

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- Remember to prefix with 'Fixes' if it should close the issue (e.g. 'Fixes #123'). -->

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
