### PR TITLE
Bump valkey-glide version 2.4.0

### DIFF
--- a/aiocache/backends/valkey.py
+++ b/aiocache/backends/valkey.py
@@ -10,7 +10,7 @@ from glide import (
     GlideClient,
     GlideClientConfiguration,
 )
-from glide.exceptions import RequestError as IncrbyException
+from glide import RequestError as IncrbyException
 
 from aiocache.base import BaseCache
 from aiocache.serializers import JsonSerializer

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ pytest==8.4.2
 pytest-asyncio==1.2.0
 pytest-cov==7.0.0
 pytest-mock==3.15.1
-valkey-glide==2.0.1
+valkey-glide==2.4.0

--- a/tests/ut/backends/test_valkey.py
+++ b/tests/ut/backends/test_valkey.py
@@ -3,7 +3,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 from glide import Batch, ConditionalChange, ExpirySet, ExpiryType
-from glide.exceptions import RequestError
+from glide import RequestError
 
 from aiocache.backends.valkey import ValkeyCache
 from aiocache.base import BaseCache


### PR DESCRIPTION
## What do these changes do?

Bump valkey-glide depdency version from 2.0.1 to 2.4.0 and update import statements to comply with `glide` package.


## Are there changes in behavior for the user?

These changes should be absolutely transparent to the user.

There is a dependabot PR created to bump to version 2.2.3 but it is oudated.
https://github.com/aio-libs/aiocache/pull/1073

## Related issue number

None

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes

